### PR TITLE
Improved debuging if destination file is missing

### DIFF
--- a/lib/instance_agent/codedeploy_plugin/application_specification/file_info.rb
+++ b/lib/instance_agent/codedeploy_plugin/application_specification/file_info.rb
@@ -11,7 +11,7 @@ module InstanceAgent
           if(source.nil?)
             raise AppSpecValidationException, 'File needs to have a source'
           elsif (destination.nil?)
-            raise AppSpecValidationException, 'File needs to have a destination'
+            raise AppSpecValidationException, "File #{source} needs to have a destination"
           end
           @source = source
           @destination = destination

--- a/test/instance_agent/codedeploy_plugin/application_specification_test.rb
+++ b/test/instance_agent/codedeploy_plugin/application_specification_test.rb
@@ -269,7 +269,7 @@ module InstanceAgent
               end
 
               should  "raise and AppSpecValidationException" do
-                assert_raised_with_message('File needs to have a destination',AppSpecValidationException) do
+                assert_raised_with_message('File test_source needs to have a destination',AppSpecValidationException) do
                   make_app_spec()
                 end
               end


### PR DESCRIPTION
This PR should improve debugging if you miss the destination key in the files hash. 