### PR TITLE
support for proxy_uri configuration option

### DIFF
--- a/conf/codedeployagent.yml
+++ b/conf/codedeployagent.yml
@@ -6,3 +6,4 @@
 :root_dir: '/opt/codedeploy-agent/deployment-root'
 :verbose: false
 :wait_between_runs: 1
+#:proxy_uri:

--- a/conf/codedeployagent.yml
+++ b/conf/codedeployagent.yml
@@ -6,4 +6,4 @@
 :root_dir: '/opt/codedeploy-agent/deployment-root'
 :verbose: false
 :wait_between_runs: 1
-#:proxy_uri:
+:proxy_uri:

--- a/lib/instance_agent/config.rb
+++ b/lib/instance_agent/config.rb
@@ -31,7 +31,8 @@ module InstanceAgent
         :wait_between_runs => 30,
         :wait_after_error => 30,
         :codedeploy_test_profile => 'prod',
-        :on_premises_config_file => '/etc/codedeploy-agent/conf/codedeploy.onpremises.yml'
+        :on_premises_config_file => '/etc/codedeploy-agent/conf/codedeploy.onpremises.yml',
+        :proxy_uri => nil
       })
     end
 

--- a/lib/instance_agent/plugins/codedeploy/codedeploy_control.rb
+++ b/lib/instance_agent/plugins/codedeploy/codedeploy_control.rb
@@ -22,6 +22,11 @@ module InstanceAgent
               64 * 1024 * 1024),
               :http_wire_trace => true})
           end
+
+          if InstanceAgent::Config.config[:proxy_uri]
+            @options = options.update({
+              :http_proxy => URI(InstanceAgent::Config.config[:proxy_uri]) })
+          end
         end
 
         def validate_ssl_config
@@ -65,6 +70,15 @@ module InstanceAgent
           client.use_ssl = true
           client.verify_mode = OpenSSL::SSL::VERIFY_PEER
           client.ca_file = ENV['SSL_CERT_FILE']
+
+          if InstanceAgent::Config.config[:proxy_uri]
+            proxy_uri = URI(InstanceAgent::Config.config[:proxy_uri])
+            client.proxy_from_env = false # make sure proxy settings can be overridden
+            client.proxy_address = proxy_uri.host
+            client.proxy_port = proxy_uri.port
+            client.proxy_user = proxy_uri.user if proxy_uri.user
+            client.proxy_pass = proxy_uri.password if proxy_uri.password 
+          end
 
           client.verify_callback = lambda do |preverify_ok, cert_store|
             return false unless preverify_ok

--- a/test/instance_agent/config_test.rb
+++ b/test/instance_agent/config_test.rb
@@ -27,7 +27,8 @@ class InstanceAgentConfigTest < InstanceAgentTestCase
         :wait_between_runs => 30,
         :wait_after_error => 30,
         :codedeploy_test_profile => 'prod',
-        :on_premises_config_file => '/etc/codedeploy-agent/conf/codedeploy.onpremises.yml'
+        :on_premises_config_file => '/etc/codedeploy-agent/conf/codedeploy.onpremises.yml',
+        :proxy_uri => nil
       }, InstanceAgent::Config.config)
     end
 


### PR DESCRIPTION
This adds a proxy_uri configuration option

This configuration option is useful/necessary because ruby does not automatically detect credentials for authenticated proxies from the `http_proxy` environment variable.  

It might be possible to do this without a configuration option by detecting the `http_proxy` environment variable, or using that value as a default.  I think an explicit configuration option is clearer and more powerful.

Where Seahorse clients are initialized, the http_proxy configuration option is now passed to them.

Certificate validation uses net/http, proxy settings are explicitly overridden if this configuration option is provided.
