### PR TITLE
Add proxy support and change S3 uri to use virtual hosting

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -52,8 +52,9 @@ begin
   def usage
     print <<EOF
 
-install [--sanity-check] <package-type>
+install [--sanity-check] [--proxy http://hostname:port] <package-type>
    --sanity-check [optional]
+   --proxy [optional]
    package-type: 'rpm', 'deb', or 'auto'
 
 Installs fetches the latest package version of the specified type and
@@ -71,6 +72,9 @@ the gdebi will be installed using apt-get first.
 
 If --sanity-check is specified, the install script will wait for 3 minutes post installation
 to check for a running agent.
+
+To use a HTTP proxy, specify --proxy followed by the proxy server
+defined by http://hostname:port
 
 This install script needs Ruby version 2.0.x installed as a prerequisite.
 If you do not have Ruby version 2.0.x installed, please install it first.
@@ -116,9 +120,10 @@ EOF
 
     @sanity_check = false
     @reexeced = false
+    @http_proxy = nil
     
     @args = Array.new(ARGV)
-    opts = GetoptLong.new(['--sanity-check', GetoptLong::NO_ARGUMENT], ['--help', GetoptLong::NO_ARGUMENT], ['--re-execed', GetoptLong::NO_ARGUMENT])
+    opts = GetoptLong.new(['--sanity-check', GetoptLong::NO_ARGUMENT], ['--help', GetoptLong::NO_ARGUMENT], ['--re-execed', GetoptLong::NO_ARGUMENT], ['--proxy', GetoptLong::OPTIONAL_ARGUMENT])
     opts.each do |opt, args|
       case opt
       when '--sanity-check'
@@ -127,6 +132,10 @@ EOF
         usage
       when '--re-execed'
         @reexeced = true
+      when '--proxy'
+        if (args != '')
+          @http_proxy = args
+        end
       end
     end
     if (ARGV.length < 1)
@@ -209,9 +218,9 @@ EOF
 
   def get_s3_uri(region, bucket, key)
     if (region == 'us-east-1')
-      URI.parse("https://s3.amazonaws.com/#{bucket}/#{key}")
+      URI.parse("https://#{bucket}.s3.amazonaws.com/#{key}")
     else
-      URI.parse("https://s3-#{region}.amazonaws.com/#{bucket}/#{key}")
+      URI.parse("https://#{bucket}.s3-#{region}.amazonaws.com/#{key}")
     end
   end
 
@@ -222,7 +231,7 @@ EOF
 
     # stream package file to disk
     begin
-      uri.open(:ssl_verify_mode => OpenSSL::SSL::VERIFY_PEER, :redirect => true, :read_timeout => 120) do |s3|
+      uri.open(:ssl_verify_mode => OpenSSL::SSL::VERIFY_PEER, :redirect => true, :read_timeout => 120, :proxy => @http_proxy) do |s3|
         package_file.write(s3.read)
       end
     rescue OpenURI::HTTPError => e
@@ -239,7 +248,7 @@ EOF
     begin
       require 'json'
 
-      version_string = uri.read(:ssl_verify_mode => OpenSSL::SSL::VERIFY_PEER, :redirect => true, :read_timeout => 120)
+      version_string = uri.read(:ssl_verify_mode => OpenSSL::SSL::VERIFY_PEER, :redirect => true, :read_timeout => 120, :proxy => @http_proxy)
       JSON.parse(version_string)
     rescue OpenURI::HTTPError => e
       @log.error("Could not find version file to download at '#{uri.to_s}'")


### PR DESCRIPTION
Add HTTP proxy support (new optional parameter)
Change the way S3 uri are generated: use virtual hosting (bucket in the hostname) to allow filtering on domain names