### PR TITLE
Add support for running hooks with sudo

### DIFF
--- a/init.d/codedeploy-agent
+++ b/init.d/codedeploy-agent
@@ -17,11 +17,14 @@
 #                    the deployment artifacts on to this instance.
 ### END INIT INFO
 
+# Source function library.
+. /etc/rc.d/init.d/functions
 
 RETVAL=0
 [ -f /etc/profile ] && [ "`stat --format '%U %G' /etc/profile`" == "root root" ] && source /etc/profile
 
 prog="codedeploy-agent"
+USER=""
 AGENT_ROOT="/opt/codedeploy-agent/"
 INSTALLER="/opt/codedeploy-agent/bin/install"
 BIN="/opt/codedeploy-agent/bin/codedeploy-agent"
@@ -29,34 +32,54 @@ BIN="/opt/codedeploy-agent/bin/codedeploy-agent"
 start() {
         echo -n $"Starting $prog:"
         cd $AGENT_ROOT
-        nohup $BIN start >/dev/null </dev/null 2>&1  # Try to start the server
+        if [ $USER ]; then
+          daemon --user=$USER $BIN start >/dev/null </dev/null 2>&1 # Try to start the server
+        else
+          nohup $BIN start >/dev/null </dev/null 2>&1  # Try to start the server
+        fi
         exit $?
 }
 
 stop() {
         echo -n $"Stopping $prog:"
         cd $AGENT_ROOT
-        nohup $BIN stop >/dev/null </dev/null 2>&1  # Try to stop the server
+        if [ $USER ]; then
+          daemon --user=$USER $BIN stop >/dev/null </dev/null 2>&1  # Try to stop the server
+        else
+          nohup $BIN stop >/dev/null </dev/null 2>&1  # Try to stop the server
+        fi
         exit $?
 }
 
 restart() {
         echo -n $"Restarting $prog:"
         cd $AGENT_ROOT
-        nohup $BIN restart >/dev/null </dev/null 2>&1  # Try to restart the server
+        if [ $USER ]; then
+          daemon --user=$USER $BIN restart >/dev/null </dev/null 2>&1  # Try to restart the server
+        else
+          nohup $BIN restart >/dev/null </dev/null 2>&1  # Try to restart the server
+        fi
         exit $?
 }
 
 status() {
         cd $AGENT_ROOT
-        $BIN status # Status of the server
+        if [ $USER ]; then
+          daemon --user=$USER $BIN status # Status of the server
+        else
+          $BIN status # Status of the server
+        fi
         exit $?
 }
 
 update() {
         echo -n $"Updating $prog:"
         cd $AGENT_ROOT
-        $INSTALLER auto #Update the agent
+        if [ $USER ]; then
+          daemon --user=$USER sudo $INSTALLER auto #Update the agent
+        else
+          $INSTALLER auto #Update the agent
+        fi
 }
 
 case "$1" in

--- a/lib/instance_agent/platform/linux_util.rb
+++ b/lib/instance_agent/platform/linux_util.rb
@@ -8,17 +8,25 @@ module InstanceAgent
       ['linux']
     end
 
-    def self.prepare_script_command(script, absolute_path)
-      script_command = absolute_path
-      if(!script.runas.nil? && script.sudo.nil?)
-        script_command = 'su ' + script.runas + ' -c ' + absolute_path
-      elsif(script.runas.nil? && script.sudo.nil?)
-        script_command = 'sudo ' + script.runas + ' -c ' + absolute_path
-      elsif(!script.runas.nil? && !script.sudo.nil?)
-        script_command = 'sudo su ' + script.runas + ' -c ' + absolute_path
+    def self.prepare_script_command(script, absolute_cmd_path)
+      runas = !!script.runas
+      sudo = !!script.sudo
+
+      if runas && sudo
+        return 'sudo su ' + script.runas + ' -c ' + absolute_cmd_path
       end
-      log(:debug, "Executing: #{script_command}")
-      script_command
+
+      if runas && !sudo
+        return 'su ' + script.runas + ' -c ' + absolute_cmd_path
+      end
+
+      if !runas && sudo
+        return 'sudo ' + absolute_cmd_path
+      end
+
+      # Execute the command as the code deploy agent user if 
+      # neither sudo or runas is specified
+      return absolute_cmd_path
     end
 
     def self.quit()

--- a/lib/instance_agent/platform/linux_util.rb
+++ b/lib/instance_agent/platform/linux_util.rb
@@ -11,13 +11,13 @@ module InstanceAgent
     def self.prepare_script_command(script, absolute_path)
       script_command = absolute_path
       if(!script.runas.nil? && script.sudo.nil?)
-				log(:info, "runas specified, running as #{script.runas}")
+        log(:info, "runas specified, running as #{script.runas}")
         script_command = 'su ' + script.runas + ' -c ' + absolute_path
 			elsif(script.runas.nil? && script.sudo.nil?)
-				log(:info, "sudo specified, running as current user with sudo")
+        log(:info, "sudo specified, running as current user with sudo")
         script_command = 'sudo ' + script.runas + ' -c ' + absolute_path
       elsif(!script.runas.nil? && !script.sudo.nil?)
-				log(:info, "runas with sudo specified, running as #{script.runas}")
+        log(:info, "runas with sudo specified, running as #{script.runas}")
         script_command = 'sudo su ' + script.runas + ' -c ' + absolute_path
       end
       script_command

--- a/lib/instance_agent/platform/linux_util.rb
+++ b/lib/instance_agent/platform/linux_util.rb
@@ -11,13 +11,10 @@ module InstanceAgent
     def self.prepare_script_command(script, absolute_path)
       script_command = absolute_path
       if(!script.runas.nil? && script.sudo.nil?)
-        log(:debug, "runas specified, running as #{script.runas}")
         script_command = 'su ' + script.runas + ' -c ' + absolute_path
       elsif(script.runas.nil? && script.sudo.nil?)
-        log(:debug, "sudo specified, running as current user with sudo")
         script_command = 'sudo ' + script.runas + ' -c ' + absolute_path
       elsif(!script.runas.nil? && !script.sudo.nil?)
-        log(:debug, "runas with sudo specified, running as #{script.runas}")
         script_command = 'sudo su ' + script.runas + ' -c ' + absolute_path
       end
       script_command

--- a/lib/instance_agent/platform/linux_util.rb
+++ b/lib/instance_agent/platform/linux_util.rb
@@ -10,8 +10,10 @@ module InstanceAgent
 
     def self.prepare_script_command(script, absolute_path)
       script_command = absolute_path
-      if(!script.runas.nil?)
+      if(!script.runas.nil? && script.sudo.nil?)
         script_command = 'su ' + script.runas + ' -c ' + absolute_path
+      elsif(!script.runas.nil? && !script.sudo.nil?)
+        script_command = 'sudo su ' + script.runas + ' -c ' + absolute_path
       end
       script_command
     end

--- a/lib/instance_agent/platform/linux_util.rb
+++ b/lib/instance_agent/platform/linux_util.rb
@@ -11,13 +11,13 @@ module InstanceAgent
     def self.prepare_script_command(script, absolute_path)
       script_command = absolute_path
       if(!script.runas.nil? && script.sudo.nil?)
-        log(:info, "runas specified, running as #{script.runas}")
+        log(:debug, "runas specified, running as #{script.runas}")
         script_command = 'su ' + script.runas + ' -c ' + absolute_path
       elsif(script.runas.nil? && script.sudo.nil?)
-        log(:info, "sudo specified, running as current user with sudo")
+        log(:debug, "sudo specified, running as current user with sudo")
         script_command = 'sudo ' + script.runas + ' -c ' + absolute_path
       elsif(!script.runas.nil? && !script.sudo.nil?)
-        log(:info, "runas with sudo specified, running as #{script.runas}")
+        log(:debug, "runas with sudo specified, running as #{script.runas}")
         script_command = 'sudo su ' + script.runas + ' -c ' + absolute_path
       end
       script_command

--- a/lib/instance_agent/platform/linux_util.rb
+++ b/lib/instance_agent/platform/linux_util.rb
@@ -17,6 +17,7 @@ module InstanceAgent
       elsif(!script.runas.nil? && !script.sudo.nil?)
         script_command = 'sudo su ' + script.runas + ' -c ' + absolute_path
       end
+      log(:debug, "Executing: #{script_command}")
       script_command
     end
 

--- a/lib/instance_agent/platform/linux_util.rb
+++ b/lib/instance_agent/platform/linux_util.rb
@@ -13,6 +13,9 @@ module InstanceAgent
       if(!script.runas.nil? && script.sudo.nil?)
 				log(:info, "runas specified, running as #{script.runas}")
         script_command = 'su ' + script.runas + ' -c ' + absolute_path
+			elsif(script.runas.nil? && script.sudo.nil?)
+				log(:info, "sudo specified, running as current user with sudo")
+        script_command = 'sudo ' + script.runas + ' -c ' + absolute_path
       elsif(!script.runas.nil? && !script.sudo.nil?)
 				log(:info, "runas with sudo specified, running as #{script.runas}")
         script_command = 'sudo su ' + script.runas + ' -c ' + absolute_path

--- a/lib/instance_agent/platform/linux_util.rb
+++ b/lib/instance_agent/platform/linux_util.rb
@@ -11,8 +11,10 @@ module InstanceAgent
     def self.prepare_script_command(script, absolute_path)
       script_command = absolute_path
       if(!script.runas.nil? && script.sudo.nil?)
+				log(:info, "runas specified, running as #{script.runas}")
         script_command = 'su ' + script.runas + ' -c ' + absolute_path
       elsif(!script.runas.nil? && !script.sudo.nil?)
+				log(:info, "runas with sudo specified, running as #{script.runas}")
         script_command = 'sudo su ' + script.runas + ' -c ' + absolute_path
       end
       script_command

--- a/lib/instance_agent/platform/linux_util.rb
+++ b/lib/instance_agent/platform/linux_util.rb
@@ -13,7 +13,7 @@ module InstanceAgent
       if(!script.runas.nil? && script.sudo.nil?)
         log(:info, "runas specified, running as #{script.runas}")
         script_command = 'su ' + script.runas + ' -c ' + absolute_path
-			elsif(script.runas.nil? && script.sudo.nil?)
+      elsif(script.runas.nil? && script.sudo.nil?)
         log(:info, "sudo specified, running as current user with sudo")
         script_command = 'sudo ' + script.runas + ' -c ' + absolute_path
       elsif(!script.runas.nil? && !script.sudo.nil?)

--- a/lib/instance_agent/platform/linux_util.rb
+++ b/lib/instance_agent/platform/linux_util.rb
@@ -24,9 +24,9 @@ module InstanceAgent
         return 'sudo ' + absolute_cmd_path
       end
 
-      # Execute the command as the code deploy agent user if 
-      # neither sudo or runas is specified
-      return absolute_cmd_path
+      # If neither sudo or runas is specified, execute the
+      # command as the code deploy agent user 
+      absolute_cmd_path
     end
 
     def self.quit()

--- a/lib/instance_agent/plugins/codedeploy/application_specification/application_specification.rb
+++ b/lib/instance_agent/plugins/codedeploy/application_specification/application_specification.rb
@@ -60,6 +60,7 @@ module InstanceAgent
                   current_hook_scripts << InstanceAgent::Plugins::CodeDeployPlugin::ApplicationSpecification::ScriptInfo.new(script['location'].to_s.strip,
                   {
                     :runas => script.has_key?('runas') && !script['runas'].nil? ? script['runas'].to_s.strip : nil,
+										:sudo => script['sudo'],
                     :timeout => script['timeout']
                   })
                 else

--- a/lib/instance_agent/plugins/codedeploy/application_specification/application_specification.rb
+++ b/lib/instance_agent/plugins/codedeploy/application_specification/application_specification.rb
@@ -60,7 +60,7 @@ module InstanceAgent
                   current_hook_scripts << InstanceAgent::Plugins::CodeDeployPlugin::ApplicationSpecification::ScriptInfo.new(script['location'].to_s.strip,
                   {
                     :runas => script.has_key?('runas') && !script['runas'].nil? ? script['runas'].to_s.strip : nil,
-										:sudo => script['sudo'],
+                    :sudo => script['sudo'],
                     :timeout => script['timeout']
                   })
                 else

--- a/lib/instance_agent/plugins/codedeploy/application_specification/script_info.rb
+++ b/lib/instance_agent/plugins/codedeploy/application_specification/script_info.rb
@@ -5,7 +5,7 @@ module InstanceAgent
         #Helper Class for storing data parsed from hook script maps
         class ScriptInfo
 
-          attr_reader :location, :runas, :timeout
+          attr_reader :location, :runas, :sudo, :timeout
           def initialize(location, opts = {})
             location = location.to_s
             if(location.empty?)
@@ -13,6 +13,7 @@ module InstanceAgent
             end
             @location = location
             @runas = opts[:runas]
+            @sudo = opts[:sudo]
             @timeout = opts[:timeout] || 3600
             @timeout = @timeout.to_i
             if(@timeout <= 0)

--- a/test/instance_agent/platform/linux_util_test.rb
+++ b/test/instance_agent/platform/linux_util_test.rb
@@ -1,0 +1,29 @@
+require './test_helper'
+
+class LinuxUtilTest < InstanceAgentTestCase
+	context 'Testing building command with sudo' do
+		setup do
+			@script_mock = Struct.new :sudo, :runas
+		end
+
+		should 'return command with sudo with runas user deploy' do
+			mock = @script_mock.new true, "deploy"
+			assert_equal 'sudo su deploy -c my_script.sh',
+				InstanceAgent::LinuxUtil.prepare_script_command(mock, "my_script.sh")
+		end
+
+		should 'return command without sudo with runas user deploy' do
+			mock = @script_mock.new nil, "deploy"
+			assert_equal 'su deploy -c my_script.sh',
+				InstanceAgent::LinuxUtil.prepare_script_command(mock, "my_script.sh")
+		end
+
+		should 'return command without sudo or runas user' do
+			mock = @script_mock.new nil, nil
+			assert_equal 'my_script.sh',
+				InstanceAgent::LinuxUtil.prepare_script_command(mock, "my_script.sh")
+		end
+
+	end
+end
+

--- a/test/instance_agent/platform/linux_util_test.rb
+++ b/test/instance_agent/platform/linux_util_test.rb
@@ -1,35 +1,35 @@
-require './test_helper'
+require 'test_helper'
 
 class LinuxUtilTest < InstanceAgentTestCase
-	context 'Testing building command with sudo' do
-		setup do
-			@script_mock = Struct.new :sudo, :runas
-		end
+  context 'Testing building command with sudo' do
+    setup do
+      @script_mock = Struct.new :sudo, :runas
+    end
 
-		should 'return command with sudo with runas user deploy' do
-			mock = @script_mock.new true, "deploy"
-			assert_equal 'sudo su deploy -c my_script.sh',
-				InstanceAgent::LinuxUtil.prepare_script_command(mock, "my_script.sh")
-		end
+    should 'return command with sudo with runas user deploy' do
+      mock = @script_mock.new true, "deploy"
+      assert_equal 'sudo su deploy -c my_script.sh',
+                   InstanceAgent::LinuxUtil.prepare_script_command(mock, "my_script.sh")
+    end
 
-		should 'return command without sudo with runas user deploy' do
-			mock = @script_mock.new nil, "deploy"
-			assert_equal 'su deploy -c my_script.sh',
-				InstanceAgent::LinuxUtil.prepare_script_command(mock, "my_script.sh")
-		end
+    should 'return command without sudo with runas user deploy' do
+      mock = @script_mock.new nil, "deploy"
+      assert_equal 'su deploy -c my_script.sh',
+                   InstanceAgent::LinuxUtil.prepare_script_command(mock, "my_script.sh")
+    end
 
-		should 'return command without sudo or runas user' do
-			mock = @script_mock.new nil, nil
-			assert_equal 'my_script.sh',
-				InstanceAgent::LinuxUtil.prepare_script_command(mock, "my_script.sh")
-		end
+    should 'return command without sudo or runas user' do
+      mock = @script_mock.new nil, nil
+      assert_equal 'my_script.sh',
+                   InstanceAgent::LinuxUtil.prepare_script_command(mock, "my_script.sh")
+    end
 
-		should 'return command with sudo' do
-			mock = @script_mock.new true, nil
-			assert_equal 'sudo my_script.sh',
-				InstanceAgent::LinuxUtil.prepare_script_command(mock, "my_script.sh")
-		end
+    should 'return command with sudo' do
+      mock = @script_mock.new true, nil
+      assert_equal 'sudo my_script.sh',
+                   InstanceAgent::LinuxUtil.prepare_script_command(mock, "my_script.sh")
+    end
 
-	end
+  end
 end
 

--- a/test/instance_agent/platform/linux_util_test.rb
+++ b/test/instance_agent/platform/linux_util_test.rb
@@ -24,6 +24,12 @@ class LinuxUtilTest < InstanceAgentTestCase
 				InstanceAgent::LinuxUtil.prepare_script_command(mock, "my_script.sh")
 		end
 
+		should 'return command with sudo' do
+			mock = @script_mock.new true, nil
+			assert_equal 'sudo my_script.sh',
+				InstanceAgent::LinuxUtil.prepare_script_command(mock, "my_script.sh")
+		end
+
 	end
 end
 


### PR DESCRIPTION
Code Deploy,

This PR is meant to open a conversation around adding support for running hooks with sudo.  We have a requirement to run commands as sudo to provide additional logs to our operation center. There is also a secondary to desire to run the code deploy agent as a non-root user (if possible).

You can add now add sudo to hooks to have them executed with sudo:

```yaml
version: 0.0
os: linux
files:
  - source: /index.html
    destination: /var/www/html/
hooks:
  BeforeInstall:
    - location: scripts/install_dependencies
      timeout: 300
      runas: root
      sudo: true
    - location: scripts/start_server
      timeout: 300
      runas: root
      sudo: true
  ApplicationStop:
    - location: scripts/stop_server
      timeout: 300
      runas: root
      sudo: true
```

This has also been tested to allow for running the code deploy agent as a non root user (https://github.com/aws/aws-codedeploy-agent/issues/5) on RHEL 7 via the following process:

```
useradd deploy
yum install ruby
aws s3 cp s3://aws-codedeploy-us-west-2/latest/codedeploy-agent.noarch.rpm . --region us-west-2
rpm -ivh codedeploy-agent.noarch.rpm
chown -R deploy:deploy /var/log/aws/codedeploy-agent /opt/codedeploy-agent
chmod 755 /var/log/aws
/etc/init.d/codedeploy-agent restart
```

Please provide feedback / guidance on the approach and appropriateness of this change.