### PR TITLE
Assigning init.d script param to a variable

### DIFF
--- a/init.d/codedeploy-agent
+++ b/init.d/codedeploy-agent
@@ -17,7 +17,7 @@
 #                    the deployment artifacts on to this instance.
 ### END INIT INFO
 
-
+COMMAND=$1
 RETVAL=0
 [ -f /etc/profile ] && [ "`stat --format '%U %G' /etc/profile`" == "root root" ] && source /etc/profile
 
@@ -59,7 +59,7 @@ update() {
         $INSTALLER auto #Update the agent
 }
 
-case "$1" in
+case "$COMMAND" in
         start)
                 start
                 ;;


### PR DESCRIPTION
On centos 7.2, line 22 ends up wiping out the passed in param which always results in this output: `Usage: /etc/init.d/codedeploy-agent {start|stop|status|restart}`. Assigning it to a variable prior and using it in the switch statement get this working properly.