### PR TITLE
Add sudo support

### DIFF
--- a/init.d/codedeploy-agent
+++ b/init.d/codedeploy-agent
@@ -22,6 +22,8 @@ RETVAL=0
 [ -f /etc/profile ] && [ "`stat --format '%U %G' /etc/profile`" == "root root" ] && source /etc/profile
 
 prog="codedeploy-agent"
+# Modify the following USER variable to run the codedeploy process as a non-root user
+# Note: You also need to chown /opt/codedeploy /var/log/aws 
 USER=""
 AGENT_ROOT="/opt/codedeploy-agent/"
 INSTALLER="/opt/codedeploy-agent/bin/install"

--- a/init.d/codedeploy-agent
+++ b/init.d/codedeploy-agent
@@ -22,6 +22,7 @@ RETVAL=0
 [ -f /etc/profile ] && [ "`stat --format '%U %G' /etc/profile`" == "root root" ] && source /etc/profile
 
 prog="codedeploy-agent"
+USER=""
 AGENT_ROOT="/opt/codedeploy-agent/"
 INSTALLER="/opt/codedeploy-agent/bin/install"
 BIN="/opt/codedeploy-agent/bin/codedeploy-agent"
@@ -29,27 +30,43 @@ BIN="/opt/codedeploy-agent/bin/codedeploy-agent"
 start() {
         echo -n $"Starting $prog:"
         cd $AGENT_ROOT
-        nohup $BIN start >/dev/null </dev/null 2>&1  # Try to start the server
+        if [ $USER ]; then
+          nohup sudo -i -u $USER $BIN start >/dev/null </dev/null 2>&1 # Try to start the server
+        else
+          nohup $BIN start >/dev/null </dev/null 2>&1  # Try to start the server
+        fi
         exit $?
 }
 
 stop() {
         echo -n $"Stopping $prog:"
         cd $AGENT_ROOT
-        nohup $BIN stop >/dev/null </dev/null 2>&1  # Try to stop the server
+        if [ $USER ]; then
+          nohup sudo -i -u $USER $BIN stop >/dev/null </dev/null 2>&1  # Try to stop the server
+        else
+          nohup $BIN stop >/dev/null </dev/null 2>&1  # Try to stop the server
+        fi
         exit $?
 }
 
 restart() {
         echo -n $"Restarting $prog:"
         cd $AGENT_ROOT
-        nohup $BIN restart >/dev/null </dev/null 2>&1  # Try to restart the server
+        if [ $USER ]; then
+          nohup sudo -i -u $USER $BIN restart >/dev/null </dev/null 2>&1  # Try to restart the server
+        else
+          nohup $BIN restart >/dev/null </dev/null 2>&1  # Try to restart the server
+        fi
         exit $?
 }
 
 status() {
         cd $AGENT_ROOT
-        $BIN status # Status of the server
+        if [ $USER ]; then
+          sudo -i -u $USER $BIN status # Status of the server
+        else
+          $BIN status # Status of the server
+        fi
         exit $?
 }
 

--- a/init.d/codedeploy-agent.service
+++ b/init.d/codedeploy-agent.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=AWS CodeDeploy Host Agent
+
+[Service]
+Type=forking
+ExecStart=/opt/codedeploy-agent/bin/codedeploy-agent start
+ExecStop=/opt/codedeploy-agent/bin/codedeploy-agent stop
+User=codedeploy
+RemainAfterExit=no
+
+[Install]
+WantedBy=multi-user.target

--- a/init.d/codedeploy-agent.service
+++ b/init.d/codedeploy-agent.service
@@ -6,6 +6,9 @@ Type=forking
 ExecStart=/opt/codedeploy-agent/bin/codedeploy-agent start
 ExecStop=/opt/codedeploy-agent/bin/codedeploy-agent stop
 RemainAfterExit=no
+# Comment out the following line to run the agent as the codedeploy user
+# Note: The user must first exist on the system
+#User=codedeploy
 
 [Install]
 WantedBy=multi-user.target

--- a/init.d/codedeploy-agent.service
+++ b/init.d/codedeploy-agent.service
@@ -5,7 +5,6 @@ Description=AWS CodeDeploy Host Agent
 Type=forking
 ExecStart=/opt/codedeploy-agent/bin/codedeploy-agent start
 ExecStop=/opt/codedeploy-agent/bin/codedeploy-agent stop
-User=codedeploy
 RemainAfterExit=no
 
 [Install]

--- a/lib/instance_agent/platform/linux_util.rb
+++ b/lib/instance_agent/platform/linux_util.rb
@@ -55,6 +55,10 @@ module InstanceAgent
     def self.codedeploy_version_file
       File.join(ProcessManager::Config.config[:root_dir], '..')
     end
+
+    def self.fallback_version_file
+      "/opt/codedeploy-agent"
+    end
     
     private
     def self.execute_tar_command(cmd)

--- a/lib/instance_agent/plugins/codedeploy/application_specification/application_specification.rb
+++ b/lib/instance_agent/plugins/codedeploy/application_specification/application_specification.rb
@@ -60,6 +60,7 @@ module InstanceAgent
                   current_hook_scripts << InstanceAgent::Plugins::CodeDeployPlugin::ApplicationSpecification::ScriptInfo.new(script['location'].to_s.strip,
                   {
                     :runas => script.has_key?('runas') && !script['runas'].nil? ? script['runas'].to_s.strip : nil,
+                    :sudo => script['sudo'],
                     :timeout => script['timeout']
                   })
                 else

--- a/lib/instance_agent/plugins/codedeploy/application_specification/script_info.rb
+++ b/lib/instance_agent/plugins/codedeploy/application_specification/script_info.rb
@@ -5,7 +5,7 @@ module InstanceAgent
         #Helper Class for storing data parsed from hook script maps
         class ScriptInfo
 
-          attr_reader :location, :runas, :timeout
+          attr_reader :location, :runas, :sudo, :timeout
           def initialize(location, opts = {})
             location = location.to_s
             if(location.empty?)
@@ -13,6 +13,7 @@ module InstanceAgent
             end
             @location = location
             @runas = opts[:runas]
+            @sudo = opts[:sudo]
             @timeout = opts[:timeout] || 3600
             @timeout = @timeout.to_i
             if(@timeout <= 0)

--- a/lib/instance_agent/plugins/codedeploy/command_executor.rb
+++ b/lib/instance_agent/plugins/codedeploy/command_executor.rb
@@ -11,6 +11,7 @@ module InstanceAgent
   module Plugins
     module CodeDeployPlugin
       ARCHIVES_TO_RETAIN = 5
+      
       class CommandExecutor
         class << self
           attr_reader :command_methods

--- a/lib/instance_agent/plugins/codedeploy/command_executor.rb
+++ b/lib/instance_agent/plugins/codedeploy/command_executor.rb
@@ -11,7 +11,7 @@ module InstanceAgent
   module Plugins
     module CodeDeployPlugin
       ARCHIVES_TO_RETAIN = 5
-
+      
       class CommandExecutor
         class << self
           attr_reader :command_methods

--- a/lib/instance_agent/plugins/codedeploy/command_executor.rb
+++ b/lib/instance_agent/plugins/codedeploy/command_executor.rb
@@ -11,7 +11,6 @@ module InstanceAgent
   module Plugins
     module CodeDeployPlugin
       ARCHIVES_TO_RETAIN = 5
-      
       class CommandExecutor
         class << self
           attr_reader :command_methods

--- a/test/instance_agent/platform/linux_util_test.rb
+++ b/test/instance_agent/platform/linux_util_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+class LinuxUtilTest < InstanceAgentTestCase
+  context 'Testing building command with sudo' do
+    setup do
+      @script_mock = Struct.new :sudo, :runas
+    end
+
+    should 'return command with sudo with runas user deploy' do
+      mock = @script_mock.new true, "deploy"
+      assert_equal 'sudo su deploy -c my_script.sh',
+                   InstanceAgent::LinuxUtil.prepare_script_command(mock, "my_script.sh")
+    end
+
+    should 'return command without sudo with runas user deploy' do
+      mock = @script_mock.new nil, "deploy"
+      assert_equal 'su deploy -c my_script.sh',
+                   InstanceAgent::LinuxUtil.prepare_script_command(mock, "my_script.sh")
+    end
+
+    should 'return command without sudo or runas user' do
+      mock = @script_mock.new nil, nil
+      assert_equal 'my_script.sh',
+                   InstanceAgent::LinuxUtil.prepare_script_command(mock, "my_script.sh")
+    end
+
+    should 'return command with sudo' do
+      mock = @script_mock.new true, nil
+      assert_equal 'sudo my_script.sh',
+                   InstanceAgent::LinuxUtil.prepare_script_command(mock, "my_script.sh")
+    end
+
+  end
+end
+


### PR DESCRIPTION
@suryanarayanan this is the new PR with updated init scripts.  There is a new addition ./init.d/codedeploy-agent.service for RHEL 7 systems.  I wasn't able to get the process to start using the legacy script, so I created a systemd service file.  The intent is to replace /etc/init.d/codedeploy-agent on RHEL 7 systems with this new /etc/systemd/system/codedeploy-agent.service file.

Let me know what you think.