### PR TITLE
Improve process name check

### DIFF
--- a/vendor/gems/process_manager-0.0.13/lib/process_manager/master.rb
+++ b/vendor/gems/process_manager-0.0.13/lib/process_manager/master.rb
@@ -163,7 +163,7 @@ module ProcessManager
       end
 
       def process_matcher(pid)
-        File.read("/proc/#{pid}/cmdline").include?("codedeploy")
+        File.read("/proc/#{pid}/cmdline").include?("codedeploy-agent: master")
       end
 
       def handle_pid_file       


### PR DESCRIPTION
The agent would fail to start if by chance the (stale) pidfile would reference an existing process with only *codedeploy* in its name string.

This is not that odd considering:
- The agent is set up to start at boot.
- That the stop process takes long enough so that when an instance is shut down it always leaves the pidfile behind (see related issue #55)
- The "@reboot" cronjob is sleeping for 45 seconds before executing */opt/codedeploy-agent/bin/install* wich contains **codedeploy** in the name of the process.

Add enough instances to the mix and you get this issue pretty often.

Just by checking for a more specific string in cmdline this can be avoided.