### PR TITLE
remove ruby2.0 explicit dependency

### DIFF
--- a/bin/codedeploy-agent
+++ b/bin/codedeploy-agent
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby2.0
+#!/usr/bin/env ruby
 
 # 1.9 adds realpath to resolve symlinks; 1.8 doesn't
 # have this method, so we add it so we get resolved symlinks


### PR DESCRIPTION
This removes the hardcoded ruby2.0 dependency from [bin/codeploy-agent](../blob/master/bin/codedeploy-agent). It is a complimentary pull request to https://github.com/aws/aws-codedeploy-agent/commit/cfbebaf602b881a839ff78b67725fb35e0ed095f and is one step further to fixing #61.

I'm not sure about the package build process, but it seems to me that the only thing remaining for #61 is rebuilding the packages that [bin/install](../blob/master/bin/install) pulls down.

I have tested that this runs in ubuntu xenial (16.04) using this: https://github.com/bdashrad/aws-codedeploy-agent/tree/xenial