### PR TITLE
Keep invoking the agent from bash when using systemd

### DIFF
--- a/init.d/codedeploy-agent.service
+++ b/init.d/codedeploy-agent.service
@@ -3,7 +3,7 @@ Description=AWS CodeDeploy Host Agent
 
 [Service]
 Type=forking
-ExecStart=/bin/sh -a -c '[ -f /etc/profile ] && source /etc/profile; /opt/codedeploy-agent/bin/codedeploy-agent-wrapper start'
+ExecStart=/bin/bash -a -c '[ -f /etc/profile ] && source /etc/profile; /opt/codedeploy-agent/bin/codedeploy-agent-wrapper start'
 ExecStop=/opt/codedeploy-agent/bin/codedeploy-agent-wrapper stop
 RemainAfterExit=no
 # Comment out the following line to run the agent as the codedeploy user


### PR DESCRIPTION
SysV script [invokes the agent with bash](https://github.com/aws/aws-codedeploy-agent/blob/eef9a73fa5dd715c4925fa9869e55204188177a6/init.d/codedeploy-agent#L1). Keep invoking the agent like that when using Systemd as /bin/sh can behave differently. Most notably it sets `POSIXLY_CORRECT=y` in CentOS (and also probably in RedHat)