### PR TITLE
Restart on failure in systemd unit definition.

### DIFF
--- a/init.d/codedeploy-agent.service
+++ b/init.d/codedeploy-agent.service
@@ -6,7 +6,9 @@ Type=forking
 ExecStart=/bin/bash -a -c '[ -f /etc/profile ] && source /etc/profile; /opt/codedeploy-agent/bin/codedeploy-agent-wrapper start'
 ExecStop=/opt/codedeploy-agent/bin/codedeploy-agent-wrapper stop
 RemainAfterExit=no
-# Comment out the following line to run the agent as the codedeploy user
+Restart=on-failure
+
+# Uncomment the following line to run the agent as the codedeploy user
 # Note: The user must first exist on the system
 #User=codedeploy
 


### PR DESCRIPTION
There are two reasons this is important:

1. Currently, if the service hits an error and stops, it will not be restarted by systemd.
2. If the service fails to start boot on an instance in an ASG, the instance may be left in a pending:wait state (due to the CodeDeploy ASG LifeCycle hooks) which means the instance could sit around broken for 60 minutes before the ASG will terminate it.