### PR TITLE
changed process check to execulde own process id

### DIFF
--- a/vendor/gems/process_manager-0.0.13/lib/process_manager/master.rb
+++ b/vendor/gems/process_manager-0.0.13/lib/process_manager/master.rb
@@ -163,6 +163,10 @@ module ProcessManager
       end
 
       def process_matcher(pid)
+        own_pid = $$
+        if pid == own_pid
+          return false
+        end
         File.read("/proc/#{pid}/cmdline").include?("codedeploy-agent: master")
       end
 


### PR DESCRIPTION
The codedeploy-agent.pid file sometimes remains for some reasons when os is shutdown. The new running agent could have the same process id as the process id in the pid file. As a result, the new one checks own process and self-terminate.

This will frequently occur if the boot order is always the same, and the number of processes launched from rc scripts is always the same.
