### PR TITLE
add dependency to systemd unit

### DIFF
--- a/init.d/codedeploy-agent.service
+++ b/init.d/codedeploy-agent.service
@@ -3,10 +3,12 @@ Description=AWS CodeDeploy Host Agent
 
 [Service]
 Type=forking
+After=network.target
 ExecStart=/bin/bash -a -c '[ -f /etc/profile ] && source /etc/profile; /opt/codedeploy-agent/bin/codedeploy-agent start'
 ExecStop=/opt/codedeploy-agent/bin/codedeploy-agent stop
 RemainAfterExit=no
 Restart=on-failure
+
 
 # Uncomment the following line to run the agent as the codedeploy user
 # Note: The user must first exist on the system


### PR DESCRIPTION
Adds a dependency to the network target. Aim is to avoid premature startup.
I'm not 100% sure this will fix *my* issue, but not specifying at least a basic dependency is not ok in any case.