### PR TITLE
Update rubyzip to latest version, fixing `can't dup NilClass`

### DIFF
--- a/codedeploy_agent-1.1.0.gemspec
+++ b/codedeploy_agent-1.1.0.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('gli', '~> 2.5')
   spec.add_dependency('json_pure', '~> 1.6')
   spec.add_dependency('archive-tar-minitar', '~> 0.5.2')
-  spec.add_dependency('rubyzip', '~> 1.1.0')
+  spec.add_dependency('rubyzip', '~> 1.2.1')
   spec.add_dependency('rake', '~> 0.9')
   spec.add_dependency('logging', '~> 1.8')
   spec.add_dependency('aws-sdk-core', '~> 2.7.1')


### PR DESCRIPTION
`rubyzip` fails on some files (specifically tested zip files created with Rust). This means the`CodeDeploy` agent always fails on those zips. The zip is valid and Finder on macOS unzips it fine.

The bug appears to already be fixed in the latest `rubyzip`:

* https://github.com/rubyzip/rubyzip/issues/82

More than a couple people are seeing this issue:

* https://forums.aws.amazon.com/thread.jspa?threadID=210427&tstart=0
* https://discuss.circleci.com/t/aws-codedeploy-cant-dup-nilclass-in-downloadbundle/3014