### PR TITLE
Allow installations via Ruby 2.4.x

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -77,7 +77,7 @@ To use a HTTP proxy, specify --proxy followed by the proxy server
 defined by http://hostname:port
 
 This install script needs Ruby version 2.x installed as a prerequisite.
-Currently recommanded Ruby versions are 2.0.0, 2.1.8, 2.2.4 and 2.3.0.
+Currently recommanded Ruby versions are 2.0.0, 2.1.8, 2.2.4, 2.3.0 and 2.4.0.
 If multiple Ruby versions are installed, the default ruby version will be used.
 If the default ruby version does not satisfy reqirement, the newest version will be used.
 If you do not have a supported Ruby version installed, please install one of them first.
@@ -86,7 +86,7 @@ EOF
   end
 
   def supported_ruby_versions
-    ['2.3', '2.2', '2.1', '2.0']
+    ['2.4', '2.3', '2.2', '2.1', '2.0']
   end
 
   # check ruby version, only version 2.x works
@@ -163,7 +163,7 @@ EOF
     # change interpreter when symlink /usr/bin/ruby2.x exists, but running with non-supported ruby version
     actual_ruby_version = RUBY_VERSION.split('.').map{|s|s.to_i}
     left_bound = '2.0.0'.split('.').map{|s|s.to_i}
-    right_bound = '2.3.1'.split('.').map{|s|s.to_i}
+    right_bound = '2.4.1'.split('.').map{|s|s.to_i}
     if (actual_ruby_version <=> left_bound) < 0
       if(!@reexeced)
         @log.info("The current Ruby version is not 2.x! Restarting the installer with #{ruby_interpreter_path}")

--- a/test/instance_agent/agent/base_test.rb
+++ b/test/instance_agent/agent/base_test.rb
@@ -48,7 +48,7 @@ class InstanceAgentBaseTest < InstanceAgentTestCase
         @base.expects(:log).with { |v1, v2| v1.eql?(:error) && v2 =~ /Error during perform/ }
         assert_nothing_raised { @base.run }
       end
-      
+
       should 'back off on repeated exceptions' do
         @base.stubs(:perform).raises Exception
         @base.expects(:sleep).with(any_of(9, 10))


### PR DESCRIPTION
Simple enough (and it installed fine for me with this change using 2.4.1). Wonder if having the upper limit on Ruby versions is actually helpful? Though I'm guessing those who've been involved in this project for some time may know better :)