### PR TITLE
Push back not_before, not_after times of test certificates

### DIFF
--- a/test/certificate_helper.rb
+++ b/test/certificate_helper.rb
@@ -24,8 +24,8 @@ class CertificateHelper
     ]
     @root_cert.issuer = @root_cert.subject
     @root_cert.public_key = @root_key.public_key
-    @root_cert.not_before = Time.now
-    @root_cert.not_after = Time.now + 60
+    @root_cert.not_before = Time.now - 10000
+    @root_cert.not_after = Time.now + 10000
     ef = OpenSSL::X509::ExtensionFactory.new
 
     ef.subject_certificate = @root_cert
@@ -52,8 +52,8 @@ class CertificateHelper
     ]
     @intermediate_cert.issuer = @root_cert.subject
     @intermediate_cert.public_key = @intermediate_key.public_key
-    @intermediate_cert.not_before = Time.now
-    @intermediate_cert.not_after = Time.now + 60
+    @intermediate_cert.not_before = Time.now - 10000
+    @intermediate_cert.not_after = Time.now + 10000
 
     ef = OpenSSL::X509::ExtensionFactory.new
     ef.subject_certificate = @intermediate_cert
@@ -80,8 +80,8 @@ class CertificateHelper
     ]
     @signer_cert.issuer = @intermediate_cert.subject
     @signer_cert.public_key = @signer_key.public_key
-    @signer_cert.not_before = Time.now
-    @signer_cert.not_after = Time.now + 60
+    @signer_cert.not_before = Time.now - 10000
+    @signer_cert.not_after = Time.now + 10000
 
     ef = OpenSSL::X509::ExtensionFactory.new
     ef.subject_certificate = @signer_cert


### PR DESCRIPTION
I was seeing random failures executing rake, and the failures mentioned PKCS7 validation errors. Looking at the helper, I saw the timeout was Time.now + 60, which seemed low. After changing it to +/-10000, I was able to execute 30+ tests in a row without failures.