### PR TITLE
Fix for #118 (agent hangs if STDOUT/STDERR left open by hook)

### DIFF
--- a/lib/instance_agent.rb
+++ b/lib/instance_agent.rb
@@ -14,6 +14,7 @@ unless defined?(InstanceAgent)
   require 'instance_agent/log'
   require 'instance_agent/platform'
   require 'instance_agent/platform/linux_util'
+  require 'instance_agent/platform/thread_joiner'
   require 'instance_agent/agent/plugin'
   require 'instance_agent/agent/base'
   require 'instance_agent/runner/master'

--- a/lib/instance_agent/platform/thread_joiner.rb
+++ b/lib/instance_agent/platform/thread_joiner.rb
@@ -1,0 +1,13 @@
+module InstanceAgent
+  class ThreadJoiner
+    def initialize(timeout_sec)
+      @timeout_epoch = Time.now.to_i + timeout_sec
+    end
+
+    def joinOrFail(thread, &block)
+      if !thread.join([@timeout_epoch - Time.now.to_i, 0].max)
+        yield(thread) if block_given?
+      end
+    end
+  end
+end

--- a/lib/instance_agent/plugins/codedeploy/hook_executor.rb
+++ b/lib/instance_agent/plugins/codedeploy/hook_executor.rb
@@ -47,6 +47,7 @@ module InstanceAgent
         SCRIPT_TIMED_OUT_CODE = 3
         SCRIPT_FAILED_CODE = 4
         UNKNOWN_ERROR_CODE = 5
+        OUTPUTS_LEFT_OPEN_CODE = 6
         def initialize(error_code, script_name, log)
           @error_code = error_code
           @script_name = script_name
@@ -151,12 +152,21 @@ module InstanceAgent
             stdin.close
             stdout_thread = Thread.new{stdout.each_line { |line| log_script("[stdout]" + line.to_s, script_log_file)}}
             stderr_thread = Thread.new{stderr.each_line { |line| log_script("[stderr]" + line.to_s, script_log_file)}}
-            if !wait_thr.join(script.timeout)
+            thread_joiner = InstanceAgent::ThreadJoiner.new(script.timeout)
+            thread_joiner.joinOrFail(wait_thr) do
               Process.kill(signal, wait_thr.pid)
               raise Timeout::Error
             end
-            stdout_thread.join
-            stderr_thread.join
+            thread_joiner.joinOrFail(stdout_thread) do
+              script_error = "Script at specified location: #{script.location} failed to close STDOUT"
+              log :error, script_error
+              raise ScriptError.new(ScriptError::OUTPUTS_LEFT_OPEN_CODE, script.location, @script_log), script_error
+            end
+            thread_joiner.joinOrFail(stderr_thread) do
+              script_error = "Script at specified location: #{script.location} failed to close STDERR"
+              log :error, script_error
+              raise ScriptError.new(ScriptError::OUTPUTS_LEFT_OPEN_CODE, script.location, @script_log), script_error
+            end
             exit_status = wait_thr.value.exitstatus
           end
           if(exit_status != 0)

--- a/test/instance_agent/platform/thread_joiner_test.rb
+++ b/test/instance_agent/platform/thread_joiner_test.rb
@@ -1,0 +1,90 @@
+require 'test_helper'
+
+class ThreadJoinerTest < InstanceAgentTestCase
+  context 'ThreadJoiner' do
+    setup do
+      @timeout_sec = 30
+      @thread1 = mock('thread1')
+      @thread2 = mock('thread2')
+      @start_time = Time.now
+      Time.stubs(:now).returns(start_time)
+      @joiner = InstanceAgent::ThreadJoiner.new(@timeout_sec)
+    end
+
+    context 'with time left' do
+      setup do
+	@thread1.expects(:join).with(@timeout_sec).returns(1)
+	@thread2.expects(:join).with(@timeout_sec - 13).returns(1)
+      end
+
+      should 'join threads with proper timeout' do
+        @joiner.joinOrFail(@thread1)
+        Time.stubs(:now).returns(@start_time + 13)
+        @joiner.joinOrFail(@thread2)
+      end
+    end
+
+    context 'with no time left' do
+      setup do
+        @thread1.expects(:join).with(0)
+        @thread2.expects(:join).with(0)
+      end
+
+      should 'join threads for zero seconds' do
+        Time.stubs(:now).returns(@start_time + @timeout_sec)
+        @joiner.joinOrFail(@thread1)
+        Time.stubs(:now).returns(@start_time + @timeout_sec + 1)
+        @joiner.joinOrFail(@thread2)
+      end
+    end
+
+    context 'when a block is provided' do
+      context 'and thread does not complete' do
+        setup do
+          @thread1.expects(:join).returns(nil)
+        end
+
+        should 'call block' do
+          called = false
+          @joiner.joinOrFail(@thread1) do
+            called = true
+          end
+
+          assert_true called
+        end
+
+        should 'pass thread to block' do
+          thread = nil
+          @joiner.joinOrFail(@thread1) do | th |
+            thread = th
+          end
+
+          assert_equal @thread1, thread
+        end
+
+        should 'propagate exception back from block' do
+          assert_raise RuntimeError do
+            @joiner.joinOrFail(@thread1) do
+              raise 'thread did not complete'
+            end
+          end
+        end
+      end
+
+      context 'and thread completes' do
+        setup do
+          @thread1.expects(:join).returns(1)
+        end
+
+        should 'not call block' do
+          called = false
+          @joiner.joinOrFail(@thread1) do
+            called = true
+          end
+
+          assert_false called
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Here's a tentative fix for Issue #118. It's tested, and relatively simple. Other enhancements, like killing the STDOUT/STDERR pump threads when their joins time out, could easily be added.

A new error code, `OUTPUTS_LEFT_OPEN_CODE = 6`, is added to the `ScriptError` class. Presumably, this could be tied to information in the AWS Console for the failed event, possibly containing a link to helpful documentation?