### PR TITLE
Fixing dependency problem with aws-sdk-core

### DIFF
--- a/codedeploy_agent-1.1.0.gemspec
+++ b/codedeploy_agent-1.1.0.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('rubyzip', '~> 1.1.0')
   spec.add_dependency('rake', '~> 10.0')
   spec.add_dependency('logging', '~> 1.8')
-  spec.add_dependency('aws-sdk-core', '~> 2.9.2')
+  spec.add_dependency('aws-sdk-core', '~> 2.6.11')
   spec.add_dependency('simple_pid', '~> 0.2.1')
   spec.add_dependency('bundler', '~> 1.3')
   spec.add_dependency('docopt', '~> 0.5.0')


### PR DESCRIPTION
aws-sdk-core conflicts with codedeploy-commands-1.0.0:
```
/usr/lib/ruby/2.1.0/rubygems/specification.rb:2064:in `raise_if_conflicts': Unable to activate codedeploy-commands-1.0.0, because aws-sdk-core-2.9.44 conflicts with aws-sdk-core (~> 2.6.11) (Gem::LoadError)
        from /usr/lib/ruby/2.1.0/rubygems/specification.rb:1262:in `activate'
        from /usr/lib/ruby/2.1.0/rubygems.rb:196:in `rescue in try_activate'
        from /usr/lib/ruby/2.1.0/rubygems.rb:193:in `try_activate'
        from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:132:in `rescue in require'
        from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:144:in `require'
        from /opt/codedeploy-local/gems/aws_codedeploy_agent-0.1/lib/instance_agent/plugins/codedeploy/codedeploy_control.rb:1:in `<top (required)>'
        from /opt/codedeploy-local/gems... (1701 more, please see e.stderr)
```