### PR TITLE
Make `github_api_url` configurable

### DIFF
--- a/lib/instance_agent/config.rb
+++ b/lib/instance_agent/config.rb
@@ -33,7 +33,8 @@ module InstanceAgent
         :codedeploy_test_profile => 'prod',
         :on_premises_config_file => '/etc/codedeploy-agent/conf/codedeploy.onpremises.yml',
         :proxy_uri => nil,
-        :enable_deployments_log => true
+        :enable_deployments_log => true,
+        :github_api_url => 'https://api.github.com'
       })
     end
 
@@ -41,6 +42,5 @@ module InstanceAgent
       errors << 'children can only be set to 1' unless config[:children] == 1
       errors
     end
-
   end
 end

--- a/lib/instance_agent/plugins/codedeploy/command_executor.rb
+++ b/lib/instance_agent/plugins/codedeploy/command_executor.rb
@@ -286,7 +286,8 @@ module InstanceAgent
             format = 'tarball'
           end
 
-          uri = URI.parse("https://api.github.com/repos/#{account}/#{repo}/#{format}/#{commit}")
+          github_api = InstanceAgent::Config.config[:github_api_url]
+          uri = URI.parse("#{github_api}/repos/#{account}/#{repo}/#{format}/#{commit}")
           options = {:ssl_verify_mode => OpenSSL::SSL::VERIFY_PEER, :redirect => true, :ssl_ca_cert => ENV['AWS_SSL_CA_DIRECTORY']}
 
           if anonymous
@@ -422,7 +423,7 @@ module InstanceAgent
 
           full_path_deployment_archives = deployment_archives.map{ |f| File.join(ProcessManager::Config.config[:root_dir], deployment_group, f)}
           full_path_deployment_archives.delete(deployment_root_dir(deployment_spec))
-          
+
           extra = full_path_deployment_archives.size - @archives_to_retain + 1
           return unless extra > 0
 

--- a/test/instance_agent/config_test.rb
+++ b/test/instance_agent/config_test.rb
@@ -29,7 +29,8 @@ class InstanceAgentConfigTest < InstanceAgentTestCase
         :codedeploy_test_profile => 'prod',
         :on_premises_config_file => '/etc/codedeploy-agent/conf/codedeploy.onpremises.yml',
         :proxy_uri => nil,
-        :enable_deployments_log => true
+        :enable_deployments_log => true,
+        :github_api_url => 'https://api.github.com'
       }, InstanceAgent::Config.config)
     end
 


### PR DESCRIPTION
The Code Deploy agent currently expects the Github API to be located at `https://api.github.com`.

For GitHub Enterprise users, this url could be at any other location (e.g. `https://development.my-company.com/api/v3`).

This pull request makes the api url configurable for people who want the agent to work with GHE. It should have no change to the default behavior.