### PR TITLE
Adding missing requires

### DIFF
--- a/lib/instance_agent/plugins/codedeploy/application_specification/application_specification.rb
+++ b/lib/instance_agent/plugins/codedeploy/application_specification/application_specification.rb
@@ -1,5 +1,7 @@
 require 'instance_agent/plugins/codedeploy/application_specification/script_info'
 require 'instance_agent/plugins/codedeploy/application_specification/file_info'
+require 'instance_agent/plugins/codedeploy/application_specification/linux_permission_info'
+require 'instance_agent/plugins/codedeploy/application_specification/mode_info'
 
 module InstanceAgent
   module Plugins


### PR DESCRIPTION
In #124 (merged) I requested to add a couple of missing 'require' so codedeploy-local doesn't fail with the following error:
```
Starting to execute deployment from within folder /opt/codedeploy-agent/deployment-root/default-local-deployment-application/d-J324JTGAR-local
/opt/codedeploy-local/gems/aws_codedeploy_agent-0.1/lib/instance_agent/plugins/codedeploy/application_specification/application_specification.rb:89:in `block in parse_permissions': uninitialized constant InstanceAgent::Plugins::CodeDeployPlugin::ApplicationSpecification::LinuxPermissionInfo (NameError)
        from /opt/codedeploy-local/gems/aws_codedeploy_agent-0.1/lib/instance_agent/plugins/codedeploy/application_specification/application_specification.rb:84:in `each'
        from /opt/codedeploy-local/gems/aws_codedeploy_agent-0.1/lib/instance_agent/plugins/codedeploy/application_specification/application_specification.rb:84:in `parse_permissions'
        from /opt/codedeploy-local/gems/aws_codedeploy_agent-0.1/lib/instance_agent/plugins/codedeploy/application_specification/application_specification.rb:21:in `initialize'
        from /opt/codedeploy-local/gems/aws_codedeploy_agent-0.1/lib/instance_agent/plugins/codedeploy/application_specification/application_specification.rb:25:in `new'
        from /opt/codedeploy-local/gems/aws_codedeploy_agent-0.1/lib/instance_agent/plugins/codedeploy/application_specification/application_specification.rb:25:in `parse'
        from /opt/codedeploy-local/gems/aws_codedeploy_agent-0.1/lib/instance_agent/plugins/codedeploy/hook_executor.rb:211:in `parse_app_spec'
        from /opt/codedeploy-local/gems/aws_codedeploy_agent-0.1/lib/instance_agent/plugins/codedeploy/hook_executor.rb:91:in `initialize'
        from /opt/codedeploy-local/gems/aws_codedeploy_agent-0.1/lib/instance_agent/plugins/codedeploy/command_executor.rb:146:in `new'
        from /opt/codedeploy-local/gems/aws_codedeploy_agent-0.1/lib/instance_agent/plugins/codedeploy/command_executor.rb:146:in `block (3 levels) in map'
        from /opt/codedeploy-local/gems/aws_codedeploy_agent-0.1/lib/instance_agent/plugins/codedeploy/command_executor.rb:145:in `each'
        from /opt/codedeploy-local/gems/aws_codedeploy_agent-0.1/lib/instance_agent/plugins/codedeploy/command_executor.rb:145:in `block (2 levels) in map'
        from /opt/codedeploy-local/gems/aws_codedeploy_agent-0.1/lib/instance_agent/plugins/codedeploy/command_executor.rb:67:in `execute_command'
        from /opt/codedeploy-local/gems/aws_codedeploy_agent-0.1/lib/aws/codedeploy/local/deployer.rb:74:in `block in execute_events'
        from /opt/codedeploy-local/gems/aws_codedeploy_agent-0.1/lib/aws/codedeploy/local/deployer.rb:73:in `each'
        from /opt/codedeploy-local/gems/aws_codedeploy_agent-0.1/lib/aws/codedeploy/local/deployer.rb:73:in `execute_events'
        from /opt/codedeploy-local/gems/aws_codedeploy_agent-0.1/bin/codedeploy-local:58:in `<main>'
```

But for some reason it was reverted in 8de07940017f6d36be5305f860a734d98c7148ea
This PR is to add missing 'require' again.