### PR TITLE
Add KillMode setting to systemd unit file

### DIFF
--- a/init.d/codedeploy-agent.service
+++ b/init.d/codedeploy-agent.service
@@ -8,6 +8,7 @@ ExecStart=/bin/bash -a -c '[ -f /etc/profile ] && source /etc/profile; /opt/code
 ExecStop=/opt/codedeploy-agent/bin/codedeploy-agent stop
 RemainAfterExit=no
 Restart=on-failure
+KillMode=process
 
 
 # Uncomment the following line to run the agent as the codedeploy user


### PR DESCRIPTION
Issue: #169
Description: this is the proposed fix for the issue above. It sets the [KillMode](https://www.freedesktop.org/software/systemd/man/systemd.kill.html#KillMode=) setting to 'process', which causes systemd to send a SIGTERM only to the parent process in CodeDeploy's CGroup.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
