### PR TITLE
Define gemspec for bundled process_manager gem

### DIFF
--- a/codedeploy_agent-1.1.0.gemspec
+++ b/codedeploy_agent-1.1.0.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency('json_pure', '~> 1.6')
   spec.add_dependency('archive-tar-minitar', '~> 0.5.2')
   spec.add_dependency('rubyzip', '~> 1.1.0')
-  spec.add_dependency('logging', '~> 1.8')
   spec.add_dependency('aws-sdk-core', '~> 2.9')
   spec.add_dependency('simple_pid', '~> 0.2.1')
   spec.add_dependency('docopt', '~> 0.5.0')

--- a/lib/instance_agent/runner/child.rb
+++ b/lib/instance_agent/runner/child.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-require 'process_manager/child'
+require 'process_manager'
 require 'thread'
 
 module InstanceAgent

--- a/lib/instance_agent/runner/master.rb
+++ b/lib/instance_agent/runner/master.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-require 'process_manager/master'
+require 'process_manager'
 require 'instance_metadata'
 require 'instance_agent/plugins/codedeploy/deployment_command_tracker'
 

--- a/vendor/gems/process_manager-0.0.13/Gemfile
+++ b/vendor/gems/process_manager-0.0.13/Gemfile
@@ -1,0 +1,3 @@
+source 'http://rubygems.org'
+
+gemspec

--- a/vendor/gems/process_manager-0.0.13/lib/process_manager.rb
+++ b/vendor/gems/process_manager-0.0.13/lib/process_manager.rb
@@ -2,46 +2,44 @@
 require 'socket'
 require 'etc'
 
-unless defined?(ProcessManager)
-  $: << File.expand_path(File.dirname(__FILE__) + '/lib')
-  require 'core_ext'
-  require 'process_manager/config'
-  require 'process_manager/log'
-  require 'process_manager/master'
-  require 'process_manager/child'
+$: << File.expand_path(File.dirname(__FILE__) + '/lib')
+require 'core_ext'
+require 'process_manager/config'
+require 'process_manager/log'
+require 'process_manager/master'
+require 'process_manager/child'
 
-  module ProcessManager
-    def self.process_running?(pid)
-      begin
-        Process.kill(0, Integer(pid))
-        return true
-      rescue Errno::EPERM # changed uid
-        return false
-      rescue Errno::ESRCH # deceased or zombied
-        return false
-      rescue
-        puts "ERROR: couldn't check the status of process #{pid}"
-        return false
-      end
+module ProcessManager
+  def self.process_running?(pid)
+    begin
+      Process.kill(0, Integer(pid))
+      return true
+    rescue Errno::EPERM # changed uid
+      return false
+    rescue Errno::ESRCH # deceased or zombied
+      return false
+    rescue
+      puts "ERROR: couldn't check the status of process #{pid}"
+      return false
     end
-
-    def self.set_program_name(name)
-      $PROGRAM_NAME = "#{ProcessManager::Config.config[:program_name]}: #{name}"
-    end
-
-    def self.on_error(&block)
-      @@_error_callbacks ||= []
-      @@_error_callbacks << block
-      nil
-    end
-
-    def self.on_error_callbacks
-      @@_error_callbacks ||= []
-    end
-
-    def self.reset_on_error_callbacks
-      @@_error_callbacks = []
-    end
-
   end
+
+  def self.set_program_name(name)
+    $PROGRAM_NAME = "#{ProcessManager::Config.config[:program_name]}: #{name}"
+  end
+
+  def self.on_error(&block)
+    @@_error_callbacks ||= []
+    @@_error_callbacks << block
+    nil
+  end
+
+  def self.on_error_callbacks
+    @@_error_callbacks ||= []
+  end
+
+  def self.reset_on_error_callbacks
+    @@_error_callbacks = []
+  end
+
 end

--- a/vendor/gems/process_manager-0.0.13/lib/process_manager.rb
+++ b/vendor/gems/process_manager-0.0.13/lib/process_manager.rb
@@ -11,8 +11,6 @@ unless defined?(ProcessManager)
   require 'process_manager/child'
 
   module ProcessManager
-    VERSION = '0.0.13'
-
     def self.process_running?(pid)
       begin
         Process.kill(0, Integer(pid))

--- a/vendor/gems/process_manager-0.0.13/lib/process_manager/version.rb
+++ b/vendor/gems/process_manager-0.0.13/lib/process_manager/version.rb
@@ -1,0 +1,3 @@
+module ProcessManager
+  VERSION = '0.0.13'
+end

--- a/vendor/gems/process_manager-0.0.13/process_manager.gemspec
+++ b/vendor/gems/process_manager-0.0.13/process_manager.gemspec
@@ -1,0 +1,12 @@
+require File.expand_path('../lib/process_manager/version', __FILE__)
+
+Gem::Specification.new do |spec|
+  spec.name          = 'process_manager'
+  spec.version       = ProcessManager::VERSION
+  spec.summary       = 'Process Manager'
+  spec.files         = Dir['{lib}/**/*']
+  spec.require_paths = ['lib']
+  spec.author        = 'Amazon Web Services'
+  spec.add_dependency('logging', '~> 1.8')
+  spec.add_dependency('simple_pid', '~> 0.2.1')
+end


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*

`process_manager` has dependency on `logging` and `simple_id` gem. In order to turn this gem to be a reusable one, it should have all knowledge of its own dependency (which is the good practice). 

This PR defines the gemspec for `process_manager` and remove the `logging` dependency (which is only used by `process_manager` gem) from the `codedeploy_agent-1.1.0.gemspec`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
