### PR TITLE
Refactor the way instance_agent_helper is required

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,4 +18,4 @@ require 'base64'
 
 # require local test helpers. If you need a helper write,
 # keep this pattern or you'll be punished hard
-require 'instance_agent_helper'
+require_relative './helpers/instance_agent_helper'


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*

When I try to run a single test, I get error report that `instance_agent_helper` cannot be loaded. Here is one example:

```
$ ruby -Itest test/instance_agent/runner/child_test.rb
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
/usr/local/var/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/activesupport-5.2.0/lib/active_support/core_ext/object/blank.rb:105: warning: already initialized constant String::BLANK_RE
/Users/tle/Work/aws-codedeploy-agent/vendor/gems/process_manager-0.0.13/lib/blank.rb:124: warning: previous definition of BLANK_RE was here
[Coveralls] Outside the CI environment, not sending data.
Traceback (most recent call last):
	4: from test/instance_agent/runner/child_test.rb:3:in `<main>'
	3: from /usr/local/var/rbenv/versions/2.5.0/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
	2: from /usr/local/var/rbenv/versions/2.5.0/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
	1: from /Users/tle/Work/aws-codedeploy-agent/test/test_helper.rb:21:in `<top (required)>'
/Users/tle/Work/aws-codedeploy-agent/test/test_helper.rb:21:in `require_relative': cannot load such file -- /Users/tle/Work/aws-codedeploy-agent/helpers/instance_agent_helper (LoadError)
```

By using `require_relative`, this PR improves how this helper is loaded. For the same example as above, after the changes:

```
$ ruby -Itest test/instance_agent/runner/child_test.rb
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
/usr/local/var/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/activesupport-5.2.0/lib/active_support/core_ext/object/blank.rb:105: warning: already initialized constant String::BLANK_RE
/Users/tle/Work/aws-codedeploy-agent/vendor/gems/process_manager-0.0.13/lib/blank.rb:124: warning: previous definition of BLANK_RE was here
Loaded suite test/instance_agent/runner/child_test
Started
/usr/local/var/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/logging-1.8.2/lib/logging/appender.rb:139: warning: constant ::Fixnum is deprecated
/usr/local/var/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/logging-1.8.2/lib/logging/logger.rb:295: warning: constant ::Fixnum is deprecated
.......
Finished in 0.060076 seconds.
------------------------------------------------------------------------------------------------------------------------------------
7 tests, 15 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
------------------------------------------------------------------------------------------------------------------------------------
116.52 tests/s, 249.68 assertions/s
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


cc @rohkat-aws 