### PR TITLE
Fix the hook execution windows tests

### DIFF
--- a/lib/instance_agent/plugins/codedeploy/hook_executor.rb
+++ b/lib/instance_agent/plugins/codedeploy/hook_executor.rb
@@ -4,7 +4,7 @@ require 'json'
 require 'fileutils'
 
 require 'instance_agent/plugins/codedeploy/application_specification/application_specification'
-
+require 'instance_agent/platform/thread_joiner'
 module InstanceAgent
   module Plugins
     module CodeDeployPlugin


### PR DESCRIPTION
 Prior to this change, The tests for windows were failing.

 This change add the necessary require in the hook_executor file.

cr https://code.amazon.com/reviews/CR-2695179

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
