### PR TITLE
Add 2.5 support on bin/update aswell

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -97,7 +97,7 @@ EOF
   end
 
   def supported_ruby_versions
-    ['2.4', '2.3', '2.2', '2.1', '2.0']
+    ['2.5', '2.4', '2.3', '2.2', '2.1', '2.0']
   end
 
   # check ruby version, only version 2.x works


### PR DESCRIPTION
*Issue #, if available:*
When executing bin/update on Ubuntu 18.04 the following error occurs

```
I, [2018-11-18T12:52:17.107054 #5065]  INFO -- : Starting Ruby version check.
E, [2018-11-18T12:52:17.107206 #5065] ERROR -- : Unhandled exception: #<TypeError: no implicit conversion of nil into String>
E, [2018-11-18T12:52:17.107241 #5065] ERROR -- :   at /opt/codedeploy-agent/bin/update:128:in `+'
E, [2018-11-18T12:52:17.107259 #5065] ERROR -- :   at /opt/codedeploy-agent/bin/update:128:in `unsupported_ruby_version_error'
E, [2018-11-18T12:52:17.107275 #5065] ERROR -- :   at /opt/codedeploy-agent/bin/update:123:in `check_ruby_version_and_symlink'
E, [2018-11-18T12:52:17.107300 #5065] ERROR -- :   at /opt/codedeploy-agent/bin/update:260:in `<main>'
```


*Description of changes:*

Add 2.5 in the array for workaround

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
