### PR TITLE
Generate a normal copy when installing a symlink of a directory

### DIFF
--- a/lib/instance_agent/plugins/codedeploy/installer.rb
+++ b/lib/instance_agent/plugins/codedeploy/installer.rb
@@ -64,7 +64,7 @@ module InstanceAgent
               fi.source)
 
               log(:debug, "generating instructions for copying #{fi.source} to #{fi.destination}")
-              if File.directory?(absolute_source_path)
+              if File.directory?(absolute_source_path) && !File.symlink?(absolute_source_path)
                 fill_in_missing_ancestors(i, fi.destination)
                 generate_directory_copy(i, absolute_source_path, fi.destination)
               else
@@ -108,7 +108,8 @@ module InstanceAgent
             absolute_source_path = absolute_source_path.force_encoding("UTF-8");
             absolute_entry_path = File.join(absolute_source_path, entry)
             entry_destination = File.join(destination, entry)
-            if File.directory?(absolute_entry_path)
+
+            if File.directory?(absolute_entry_path) && !File.symlink?(absolute_entry_path)
               generate_directory_copy(i, absolute_entry_path, entry_destination)
             else
               generate_normal_copy(i, absolute_entry_path, entry_destination)


### PR DESCRIPTION
Closes aws/aws-codedeploy-agent#152.

*Summary*

This PR makes the installer check each file if it is a symlink of a directory, and generate `normal_copy` instead of `directory_copy`.

*Description of changes:*

When the installer(`lib/instance_agent/plugins/codedeploy/installer.rb`) installs, it generates instructions for copying source files to the deploy destination. The installer recursively generates `mkdir` for directory files and `copy` instructions for regular files.

The problem occurs when a src file is a symlink of a directory. Although the symlink itself **IS** a regular file, `File.directory?(dir_symlink)` still returns `true`. Since `Dir.entries(dir_symlink)` also works as if it is a normal directory, children files of the symlink are copied instead of the symlink itself.

This PR adds a symlink check as well as a directory check when generating instructions.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
