### PR TITLE
Add the path to vendor gems in $LOAD_PATH.

### DIFF
--- a/lib/codedeploy-agent.rb
+++ b/lib/codedeploy-agent.rb
@@ -15,6 +15,7 @@ end
 # if installed as a gem
 
 agent_dir = "/opt/codedeploy-agent"
+$:.unshift *Dir.glob("#{agent_dir}/vendor/gems/**/lib")
 $:.unshift "#{agent_dir}/lib"
 # Required for integration tests to run correctly
 $:.unshift File.join(File.dirname(File.expand_path('..', __FILE__)), 'lib')


### PR DESCRIPTION
This closes #133.

### Problem

If the latest `aws-sdk-core` gem(i.e., [3.44.2](https://rubygems.org/gems/aws-sdk-core/versions/3.44.2)) is installed on the instance, an undefined method error occurs when codedeploy-agent is started.

### Cause

In command executer of codedeploy-agent, it uses a [deprecated](https://github.com/aws/aws-sdk-ruby/commit/f620737c90ce647dad76ba88c6ae4c1604ad6542#diff-513518e0586b1edf09135c3dfe1fb337) method, `Seahorse::Util::Module#underscore`. Although the old version of gem in vender directory(`/opt/codedeploy-agent/vendor/gems/`) does include the method, the agent loads locally installed gems instead of vendor gems. 

### Solution

Add the path to vendor gems, `/opt/codedeploy-agent/vendor/gems/**/lib`, in `$LOAD_PATH`.

Note that due to name collisions between files in agent and those in vendor gems, `/opt/codedeploy-agent/lib` must be placed before the vendor path in`$LOAD_PATH`. This prevents the agent from loading `/vendor/.../simple-pid/lib/core_ext.rb` instead of `/lib/core_ext.rb`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.