### PR TITLE
Issue #185: fix for "Directory not empty @ dir_s_rmdir - /var/www" on Ubuntu 18.04

### DIFF
--- a/lib/instance_agent/plugins/codedeploy/install_instruction.rb
+++ b/lib/instance_agent/plugins/codedeploy/install_instruction.rb
@@ -212,7 +212,7 @@ module InstanceAgent
               # TODO (AWSGLUE-713): handle the exception if the directory is non-empty;
               # this might mean the customer has put files in this directory and we should
               # probably ignore the error and move on
-              FileUtils.rmdir(@file_path)
+              FileUtils.rmdir(@file_path) rescue StandardError
             else
               FileUtils.rm(@file_path)
             end


### PR DESCRIPTION
*Issue #, if available:* #185 - ref.: AWSGLUE-713

*Description of changes:*
Simply added an error trapping directive and ignoring for the failing `rmdir`.

Makes codedeploy-agent compatible with Ubuntu 18.04 when deploying two different apps consecutively in the same base directory. ie.:
- `/var/www/some-api/`
- `/var/www/some-angular-app/`

This works fine on Ubuntu 16.04, but you get the following error on Ubuntu 18.04 with Ruby 2.5:
`Unknown error, Directory not empty @ dir_s_rmdir - /var/www`

It might not be the best way to do it, but it is meant to provide a solution until this officially gets fixed since it has been open since August 2018 already. It's in line with the AWSGLUE-713 comment, and we've been successfully using this patch in development and production since then.

--

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
