### PR TITLE
bugfix: pid should gt 0

### DIFF
--- a/vendor/gems/process_manager-0.0.13/lib/process_manager/master.rb
+++ b/vendor/gems/process_manager-0.0.13/lib/process_manager/master.rb
@@ -51,7 +51,7 @@ module ProcessManager
 
       def self.status
         if pid = find_pid
-          if ProcessManager::process_running?(pid)
+          if pid > 0 && ProcessManager::process_running?(pid)
             pid
           else
             clean_stale_pid


### PR DESCRIPTION
*Issue #228 , if available:*

*Description of changes:*

When the pid file is empty, `find_pid` returns 0 because ruby parses empty to zero. 

Check if pid is great then 0 before using `process_running?` to check the process. Put the pid-checking outside function `find_pid` because: empty pid file is actually a polluted state, so the pid file should be reset by `clean_stale_pid`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
