### PR TITLE
Allow to use --proxy on cron job

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -132,7 +132,7 @@ EOF
   end
 
   def parse_args()
-    if (ARGV.length > 4)
+    if (ARGV.length > 5)
       usage
       @log.error('Too many arguments.')
       exit(1)


### PR DESCRIPTION
I faced a problem that I cannot use --proxy option on cron job with 'Too many arguments.' error.

Currently, /etc/cron.d/codedeploy-agent-update is defined as follows:

```
# Cron that starts once every day or on reboot, which updates codedeploy-agent.
# This cron file has been fuzzed to run after 10:31:44 every hour.
31 10 * * * root /bin/sleep 44; /opt/codedeploy-agent/bin/update --sanity-check --upgrade rpm
1 * * * * root /bin/sleep 44; /opt/codedeploy-agent/bin/update --sanity-check --downgrade rpm
@reboot root /bin/sleep 45; /opt/codedeploy-agent/bin/update --sanity-check rpm
```

According to https://github.com/aws/aws-codedeploy-agent/blob/master/bin/update#L135, the update script can be passed up to 4 arguments. So I cannot set proxy like `31 10 * * * root /bin/sleep 44; /opt/codedeploy-agent/bin/update --sanity-check --upgrade --proxy http://x.x.x.x:yyy rpm`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
