### PR TITLE
Add support for Ruby 2.6 to the install script

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -86,7 +86,7 @@ EOF
   end
 
   def supported_ruby_versions
-    ['2.5', '2.4', '2.3', '2.2', '2.1', '2.0']
+    ['2.6', '2.5', '2.4', '2.3', '2.2', '2.1', '2.0']
   end
 
   # check ruby version, only version 2.x works


### PR DESCRIPTION
*Issue #, if available: #214 

*Description of changes:
Add support for Ruby 2.6 to the install script
And it works fine for me.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
