### PR TITLE
If a bundle is an archive of a directory, strip the leading directory

### DIFF
--- a/features/codedeploy-local/codedeploy_local.feature
+++ b/features/codedeploy-local/codedeploy_local.feature
@@ -31,6 +31,13 @@ Feature: Local Deploy using AWS CodeDeploy Local CLI
     And the expected files should have have been locally deployed to my host
     And the scripts should have been executed during local deployment
 
+  Scenario: Doing a sample local deployment using a zipped_directory bundle
+    Given I have a sample local zipped_directory bundle
+    When I create a local deployment with my bundle
+    Then the local deployment command should succeed
+    And the expected files should have have been locally deployed to my host
+    And the scripts should have been executed during local deployment
+
   Scenario: Doing a sample local deployment using a tgz bundle
     Given I have a sample local tgz bundle
     When I create a local deployment with my bundle

--- a/features/step_definitions/codedeploy_local_steps.rb
+++ b/features/step_definitions/codedeploy_local_steps.rb
@@ -58,7 +58,6 @@ def zip_app_dir_bundle(temp_directory_to_create_bundle)
     FileUtils.cp_r(StepConstants::SAMPLE_APP_BUNDLE_FULL_PATH, zip_build_dir)
     zip_directory(zip_build_dir, zip_file_name)
   }
-  FileUtils.cp(zip_file_name, "/tmp")
   zip_file_name
 end
 

--- a/features/step_definitions/codedeploy_local_steps.rb
+++ b/features/step_definitions/codedeploy_local_steps.rb
@@ -52,12 +52,16 @@ Given(/^I have a sample local (tgz|tar|zip|zipped_directory|directory|relative_d
   expect(File.file?(@bundle_location)).to be true unless bundle_type.include? 'directory'
 end
 
+# Create a zip of the bundle with a nested directory containing the actual bundle files
 def zip_app_dir_bundle(temp_directory_to_create_bundle)
   zip_file_name = "#{temp_directory_to_create_bundle}/app_dir_bundle.zip"
   Dir.mktmpdir { |zip_build_dir|
+    # Copy the bundle files into a temporary directory so we can just zip the sample bundle
     FileUtils.cp_r(StepConstants::SAMPLE_APP_BUNDLE_FULL_PATH, zip_build_dir)
     zip_directory(zip_build_dir, zip_file_name)
   }
+  # Confirm appspec.yml is not at top level
+  Zip::File.open(zip_file_name) { |zip| expect(zip.entries.map(&:name).include? "appspec.yml").to be false }
   zip_file_name
 end
 

--- a/lib/instance_agent/plugins/codedeploy/command_executor.rb
+++ b/lib/instance_agent/plugins/codedeploy/command_executor.rb
@@ -415,7 +415,7 @@ module InstanceAgent
             FileUtils.mv(nested_archive_root, dst)
             FileUtils.rmdir(tmp_dst)
 
-            log(:debug, Dir.entries(actual_dst).join("; "))            
+            log(:debug, Dir.entries(dst).join("; "))            
           end
         end
 

--- a/lib/instance_agent/plugins/codedeploy/command_executor.rb
+++ b/lib/instance_agent/plugins/codedeploy/command_executor.rb
@@ -411,10 +411,10 @@ module InstanceAgent
           archive_root_files.delete_if { |name| name == '.' || name == '..' }
 
           # If the top level of the archive is a directory, strip that before giving up
-          if (!strip_leading_directory) && (archive_root_files.size == 1) && File.directory?(archive_root_files[0])
+          if (!strip_leading_directory) && (archive_root_files.size == 1) && File.directory?(File.join(dst, archive_root_files[0]))
             log(:info, "Archived directory. Looking inside")
             strip_leading_directory = true
-
+            puts("*********************")
             dst = File.join(deployment_root_dir(deployment_spec), 'deployment-archive-temp')
             FileUtils.rm_rf(dst)
             FileUtils.mv(actual_dst, dst)

--- a/lib/instance_agent/plugins/codedeploy/command_executor.rb
+++ b/lib/instance_agent/plugins/codedeploy/command_executor.rb
@@ -401,8 +401,11 @@ module InstanceAgent
           archive_root_files = Dir.entries(dst)
           archive_root_files.delete_if { |name| name == '.' || name == '..' }
 
-          # If the top level of the archive is a directory, strip that before giving up
-          if ((archive_root_files.size == 1) && File.directory?(File.join(dst, archive_root_files[0])))
+          # If the top level of the archive is a directory that contains an appspec,
+          # strip that before giving up
+          if ((archive_root_files.size == 1) && 
+              File.directory?(File.join(dst, archive_root_files[0])) &&
+              Dir.entries(File.join(dst, archive_root_files[0])).grep(/appspec/i).any?)
             log(:info, "Stripping leading directory from archive bundle contents.")
             # Move the unpacked files to a temporary location
             tmp_dst = File.join(deployment_root_dir(deployment_spec), 'deployment-archive-temp')

--- a/lib/instance_agent/plugins/codedeploy/command_executor.rb
+++ b/lib/instance_agent/plugins/codedeploy/command_executor.rb
@@ -374,16 +374,7 @@ module InstanceAgent
 
         private
         def unpack_bundle(cmd, bundle_file, deployment_spec)
-          strip_leading_directory = deployment_spec.revision_source == 'GitHub'
-          actual_dst = File.join(deployment_root_dir(deployment_spec), 'deployment-archive')
-
-          if strip_leading_directory
-            # Extract to a temporary directory first so we can move the files around
-            dst = File.join(deployment_root_dir(deployment_spec), 'deployment-archive-temp')
-            FileUtils.rm_rf(dst)
-          else
-            dst = File.join(deployment_root_dir(deployment_spec), 'deployment-archive')
-          end
+          dst = File.join(deployment_root_dir(deployment_spec), 'deployment-archive')
 
           if "tar".eql? deployment_spec.bundle_type
             InstanceAgent::Platform.util.extract_tar(bundle_file, dst)
@@ -411,31 +402,20 @@ module InstanceAgent
           archive_root_files.delete_if { |name| name == '.' || name == '..' }
 
           # If the top level of the archive is a directory, strip that before giving up
-          if (!strip_leading_directory) && (archive_root_files.size == 1) && File.directory?(File.join(dst, archive_root_files[0]))
-            log(:info, "Archived directory. Looking inside")
-            strip_leading_directory = true
-            dst = File.join(deployment_root_dir(deployment_spec), 'deployment-archive-temp')
-            FileUtils.rm_rf(dst)
-            FileUtils.mv(actual_dst, dst)
-          end
-
-          if strip_leading_directory
+          if ((archive_root_files.size == 1) && File.directory?(File.join(dst, archive_root_files[0])))
             log(:info, "Stripping leading directory from archive bundle contents.")
+            # Move the unpacked files to a temporary location
+            tmp_dst = File.join(deployment_root_dir(deployment_spec), 'deployment-archive-temp')
+            FileUtils.rm_rf(tmp_dst)
+            FileUtils.mv(dst, tmp_dst)
 
-            # Find leading directory to remove
-            if (archive_root_files.size != 1)
-              log(:warn, "Expected archive to have a single root directory containing the actual bundle root, but it had #{archive_root_files.size} entries instead. Skipping leading directory removal and using archive as is.")
-              FileUtils.mv(dst, actual_dst)
-              return
-            end
+            # Move the top level directory to the intended location
+            nested_archive_root = File.join(tmp_dst, archive_root_files[0])
+            log(:debug, "Actual archive root at #{nested_archive_root}. Moving to #{dst}")
+            FileUtils.mv(nested_archive_root, dst)
+            FileUtils.rmdir(tmp_dst)
 
-            nested_archive_root = File.join(dst, archive_root_files[0])
-            log(:debug, "Actual archive root at #{nested_archive_root}. Moving to #{actual_dst}")
-
-            FileUtils.mv(nested_archive_root, actual_dst)
-            FileUtils.rmdir(dst)
-
-            log(:debug, Dir.entries(actual_dst).join("; "))
+            log(:debug, Dir.entries(actual_dst).join("; "))            
           end
         end
 

--- a/lib/instance_agent/plugins/codedeploy/command_executor.rb
+++ b/lib/instance_agent/plugins/codedeploy/command_executor.rb
@@ -414,7 +414,6 @@ module InstanceAgent
           if (!strip_leading_directory) && (archive_root_files.size == 1) && File.directory?(File.join(dst, archive_root_files[0]))
             log(:info, "Archived directory. Looking inside")
             strip_leading_directory = true
-            puts("*********************")
             dst = File.join(deployment_root_dir(deployment_spec), 'deployment-archive-temp')
             FileUtils.rm_rf(dst)
             FileUtils.mv(actual_dst, dst)


### PR DESCRIPTION
#Notes

We currently do this for archives produced by github but it seems generally useful (In particular, it would make the CodePipeline "My First Pipeline" tutorial simpler). This should not modify the behavior of anything that works now (modulo bugs)

#Testing

I created an integration test which runs successfully. I also successfully manually tested a prior version of this (with the same logic) in my own Deployment group.
