### PR TITLE
Remove third party packaging

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,12 +21,11 @@ jobs:
         ruby-version: ['2.6', '2.7']
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby ${{ matrix.ruby-version }}
-      uses: ruby/setup-ruby@477b21f02be01bcb8030d50f37cfec92bfa615b6
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
-    - name: Install dependencies
-      run: bundle install
+        bundler-cache: false # runs 'bundle install' and caches installed gems automatically
     - name: Run tests
       run: bundle exec rake
     - name: Coveralls

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,7 +25,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: false # runs 'bundle install' and caches installed gems automatically
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Run tests
       run: bundle exec rake
     - name: Coveralls

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,11 +21,12 @@ jobs:
         ruby-version: ['2.6', '2.7']
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+    - name: Set up Ruby ${{ matrix.ruby-version }}
+      uses: ruby/setup-ruby@477b21f02be01bcb8030d50f37cfec92bfa615b6
       with:
         ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: false # runs 'bundle install' and caches installed gems automatically
+    - name: Install dependencies
+      run: bundle install
     - name: Run tests
       run: bundle exec rake
     - name: Coveralls

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,7 +25,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+        bundler-cache: false # runs 'bundle install' and caches installed gems automatically
     - name: Run tests
       run: bundle exec rake
     - name: Coveralls

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ deployment/
 pkg/
 vendor-thirdparty/
 .bundle/
+.rakeTasks

--- a/Rakefile
+++ b/Rakefile
@@ -108,17 +108,6 @@ task :package do
   sh "cp -rf init.d #{bundle_dir}/etc/"
   sh "cp -f LICENSE #{bundle_dir}/opt/#{config[:program_name]}/"
 
-  # Vendor folder needs an extra effort, we also need to package the gems installed
-  gem_lib_folder = "vendor-thirdparty"
-
-  rubygemlibs = "#{gem_lib_folder}/ruby/#{rubygem_folder}"
-  Dir.glob("#{rubygemlibs}/gems/*") do |path|
-    sh "cp -r #{path} #{bundle_dir}/opt/#{config[:program_name]}/#{VENDOR}/gems"
-  end
-  Dir.glob("#{rubygemlibs}/specifications/*") do |path|
-    sh "cp -r #{path} #{bundle_dir}/opt/#{config[:program_name]}/#{VENDOR}/specifications"
-  end
-
   sh "sed '/group :test/,$d' Gemfile > #{bundle_dir}/opt/#{config[:program_name]}/Gemfile"
   sh "sed '/add_development_dependency/d' codedeploy_agent.gemspec > #{bundle_dir}/opt/#{config[:program_name]}/codedeploy_agent.gemspec"
 


### PR DESCRIPTION
*Description of changes:*
Remove bundling of third party software through Github to avoid man-in-the-middle attack. Third party software will be bundled by AWS internally to ensure the integrity of the packages.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
