### PR TITLE
Adding preliminary macOS support

### DIFF
--- a/bin/codedeploy-launchd
+++ b/bin/codedeploy-launchd
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Run the CodeDeploy agent in the foreground so that it
+# can be controlled by MacOS's launchd. This does away with
+# most of the Gli command-line handling stuff, since this has
+# only one way of being invoked (i.e. launchd).
+#
+# Mostly copied from the official CLI entrypoint in `lib/codedeploy-agent.rb`
+agent_dir = '/opt/aws/codedeploy'
+$LOAD_PATH.unshift "#{agent_dir}/lib"
+
+require 'instance_agent'
+
+# Always use the config file from the installation root:
+InstanceAgent::Config.config(
+  config_file: "#{agent_dir}/conf/codedeployagent.yml"
+)
+
+InstanceAgent::Platform.util = InstanceAgent::LinuxUtil
+InstanceAgent::Config.load_config
+
+# The `.new` here ensures that the master runs in the foreground instead of as
+# a daemon.
+InstanceAgent::Runner::Master.new.start

--- a/init.d/com.amazon.aws.codedeploy.plist
+++ b/init.d/com.amazon.aws.codedeploy.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>com.amazon.aws.codedeploy</string>
+    <key>UserName</key>
+    <string>root</string>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>ProgramArguments</key>
+    <array>
+      <string>/opt/aws/codedeploy/bin/codedeploy-launchd</string>
+    </array>
+    <key>KeepAlive</key>
+    <true/>
+  </dict>
+</plist>


### PR DESCRIPTION

*Issue #, if available:* 

V394150318 (internally)

*Description of changes:*

This changeset adds a launchd entrypoint and the corresponding launchd plist file. This makes it easier to run the CodeDeploy agent under macOS since launchd doesn't really support disconnected daemons.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
