### PR TITLE
Move After to proper systemd unit file section.

### DIFF
--- a/init.d/codedeploy-agent.service
+++ b/init.d/codedeploy-agent.service
@@ -1,9 +1,9 @@
 [Unit]
 Description=AWS CodeDeploy Host Agent
+After=network.target
 
 [Service]
 Type=forking
-After=network.target
 ExecStart=/bin/bash -a -c '[ -f /etc/profile ] && source /etc/profile; /opt/codedeploy-agent/bin/codedeploy-agent start'
 ExecStop=/opt/codedeploy-agent/bin/codedeploy-agent stop
 RemainAfterExit=no


### PR DESCRIPTION
Move the After= configuration statement from the [Service] section to the [Unit] section where it belongs.

The current code results in syslog messages like this:
```
11/05/2021
5:35:48.546 AM +0000
service.systemd v2 i-###########.us-east-1a ##.##.##.## undef 4 [/etc/systemd/system/codedeploy-agent.service:6] Unknown lvalue 'After' in section 'Service'
```

See syslog documentation for supporting evidence:
https://www.freedesktop.org/software/systemd/man/systemd.unit.html
https://www.freedesktop.org/software/systemd/man/systemd.service.html


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
