### PR TITLE
Allow archives with "duplicate" files to successfully extract

### DIFF
--- a/lib/instance_agent/platform/windows_util.rb
+++ b/lib/instance_agent/platform/windows_util.rb
@@ -47,7 +47,7 @@ module InstanceAgent
       FileUtils.mkdir_p(dst)
       working_dir = FileUtils.pwd()
       absolute_bundle_path = File.expand_path(bundle_file)
-      execute_zip_command("powershell [System.Reflection.Assembly]::LoadWithPartialName(‘System.IO.Compression.FileSystem’); [System.IO.Compression.ZipFile]::ExtractToDirectory(‘#{absolute_bundle_path}’, ‘#{dst}’)")
+      execute_zip_command("powershell [System.Reflection.Assembly]::LoadWithPartialName(‘System.IO.Compression.FileSystem’); [System.IO.Compression.ZipFile]::ExtractToDirectory(‘#{absolute_bundle_path}’, ‘#{dst}’, true)")
     end 
 
     def self.supports_process_groups?()


### PR DESCRIPTION
Some deployment archives have "duplicate" files. These are usually files that have names that differ only on case. This change allows them to be unextracted by the faster native unextractor by passing `true` as the third argument[1]. This mirrors the Ruby implementation's behavior without incurring in a performance penalty by using the Ruby extractor.

[1]: https://learn.microsoft.com/en-us/dotnet/api/system.io.compression.zipfile.extracttodirectory?view=net-7.0#system-io-compression-zipfile-extracttodirectory(system-string-system-string-system-boolean)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
