### PR TITLE
Ruby3.x

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7']
+        ruby-version: ['2.6', '2.7', '3.0', '3.1']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/bin/codedeploy-agent
+++ b/bin/codedeploy-agent
@@ -2,7 +2,7 @@
 
 $:.unshift File.join(File.dirname(File.expand_path('..', __FILE__)), 'lib')
 
-ruby_versions = ["2.7", "2.6", "2.5", "2.4", "2.3", "2.2", "2.1", "2.0"]
+ruby_versions = ["3.1", "3.0", "2.7", "2.6", "2.5", "2.4", "2.3", "2.2", "2.1", "2.0"]
 actual_ruby_version = RUBY_VERSION.split('.').map{|s|s.to_i}
 left_bound = '2.0.0'.split('.').map{|s|s.to_i}
 ruby_bin = nil

--- a/bin/install
+++ b/bin/install
@@ -203,7 +203,7 @@ to check for a running agent.
 To use a HTTP proxy, specify --proxy followed by the proxy server
 defined by http://hostname:port
 
-This install script needs Ruby version 2.x installed as a prerequisite.
+This install script needs Ruby version 2.x or 3.x installed as a prerequisite.
 Currently recommended Ruby versions are 2.0.0, 2.1.8, 2.2.4, 2.3, 2.4, 2.5, 2.6 and 2.7.
 If multiple Ruby versions are installed, the default ruby version will be used.
 If the default ruby version does not satisfy requirement, the newest version will be used.
@@ -213,7 +213,7 @@ EOF
   end
 
   def supported_ruby_versions
-    ['2.7', '2.6', '2.5', '2.4', '2.3', '2.2', '2.1', '2.0']
+    ['3.1', '3.0', '2.7', '2.6', '2.5', '2.4', '2.3', '2.2', '2.1', '2.0']
   end
 
   # check ruby version, only version 2.x works
@@ -241,9 +241,9 @@ EOF
   end
 
   def unsupported_ruby_version_error
-    @log.error("Current running Ruby version for "+ENV['USER']+" is "+RUBY_VERSION+", but Ruby version 2.x needs to be installed.")
+    @log.error("Current running Ruby version for "+ENV['USER']+" is "+RUBY_VERSION+", but Ruby version 2.x or 3.x needs to be installed.")
     @log.error('If you already have the proper Ruby version installed, please either create a symlink to /usr/bin/ruby2.x,')
-    @log.error( "or run this install script with right interpreter. Otherwise please install Ruby 2.x for "+ENV['USER']+" user.")
+    @log.error( "or run this install script with right interpreter. Otherwise please install Ruby 2.x or 3.x for "+ENV['USER']+" user.")
     @log.error('You can get more information by running the script with --help option.')
   end
 
@@ -296,14 +296,14 @@ EOF
     @type = ARGV.shift.downcase;
   end
 
-  def force_ruby2x(ruby_interpreter_path)
+  def force_ruby2x_or_3x(ruby_interpreter_path)
     # change interpreter when symlink /usr/bin/ruby2.x exists, but running with non-supported ruby version
     actual_ruby_version = RUBY_VERSION.split('.').map{|s|s.to_i}
     left_bound = '2.0.0'.split('.').map{|s|s.to_i}
-    right_bound = '2.7.0'.split('.').map{|s|s.to_i}
+    right_bound = '3.1.0'.split('.').map{|s|s.to_i}
     if (actual_ruby_version <=> left_bound) < 0
       if(!@reexeced)
-        @log.info("The current Ruby version is not 2.x! Restarting the installer with #{ruby_interpreter_path}")
+        @log.info("The current Ruby version is not 2.x or 3.x! Restarting the installer with #{ruby_interpreter_path}")
         exec("#{ruby_interpreter_path}", __FILE__, '--re-execed' , *@args)
       else
         unsupported_ruby_version_error
@@ -327,9 +327,9 @@ EOF
     exit(1)
   end
 
-  ########## Force running as Ruby 2.x or fail here       ##########
+  ########## Force running as Ruby 2.x or 3.x or fail here ##########
   ruby_interpreter_path = check_ruby_version_and_symlink
-  force_ruby2x(ruby_interpreter_path)
+  force_ruby2x_or_3x(ruby_interpreter_path)
 
   def run_command(*args)
     exit_ok = system(*args)

--- a/codedeploy_agent.gemspec
+++ b/codedeploy_agent.gemspec
@@ -9,13 +9,13 @@ Gem::Specification.new do |spec|
   spec.bindir        = ['bin']
   spec.require_paths = ['lib']
   spec.license        = 'Apache-2.0'
-  spec.required_ruby_version = '~> 2.0'
+  spec.required_ruby_version = '>= 2.0'
 
   spec.add_dependency('gli', '~> 2.5')
-  spec.add_dependency('json_pure', '~> 1.6')
+  spec.add_dependency('json_pure', '~> 2.6')
   spec.add_dependency('archive-tar-minitar', '~> 0.5.2')
   spec.add_dependency('rubyzip', '~> 1.3.0')
-  spec.add_dependency('logging', '~> 1.8')
+  spec.add_dependency('logging', '~> 2.3')
   spec.add_dependency('aws-sdk-core', '~> 3')
   spec.add_dependency('aws-sdk-code-generator', '~> 0.2.2.pre')
   spec.add_dependency('aws-sdk-s3', '~> 1')

--- a/spec/aws/codedeploy/local/deployer_spec.rb
+++ b/spec/aws/codedeploy/local/deployer_spec.rb
@@ -50,6 +50,8 @@ describe AWS::CodeDeploy::Local::Deployer do
     allow(File).to receive(:exists?).with(AWS::CodeDeploy::Local::Deployer::CONF_DEFAULT_LOCATION).and_return(false)
     allow(File).to receive(:readable?).with(AWS::CodeDeploy::Local::Deployer::CONF_DEFAULT_LOCATION).and_return(false)
     allow(File).to receive(:readable?).with(InstanceAgent::Config.config[:on_premises_config_file]).and_return(false)
+    # The logging lib checks if files exist; let it do that without throwing errors or needing to care which files
+    allow(File).to receive(:file?).and_call_original
   end
 
   def create_config_file(working_directory, log_dir = nil)
@@ -84,6 +86,7 @@ describe AWS::CodeDeploy::Local::Deployer do
     end
 
     it 'tries to load configuration if the configuration file location provided is nil' do
+      
       expect(File).to receive(:file?).with(AWS::CodeDeploy::Local::Deployer::CONF_DEFAULT_LOCATION).and_return(true)
       expect(File).to receive(:readable?).with(AWS::CodeDeploy::Local::Deployer::CONF_DEFAULT_LOCATION).and_return(true)
       expect(File).to receive(:file?).with(InstanceAgent::Config.config[:on_premises_config_file]).and_return(false)

--- a/test/helpers/instance_agent_helper.rb
+++ b/test/helpers/instance_agent_helper.rb
@@ -21,7 +21,6 @@ class InstanceAgentTestCase < Test::Unit::TestCase
   end
 
   def assert_raised_with_message(message, error_type = RuntimeError)
-    error = assert_raise(error_type) { yield }
-    assert_equal(message, error.message)
+    assert_raise_with_message(error_type, message) { yield }
   end
 end

--- a/test/instance_agent/plugins/codedeploy/deployment_specification_test.rb
+++ b/test/instance_agent/plugins/codedeploy/deployment_specification_test.rb
@@ -480,7 +480,7 @@ class DeploymentSpecificationTest < InstanceAgentTestCase
         should "raise when JSON submitted as PKCS7/JSON" do
           @packed_message.payload = @deployment_spec.to_json
 
-          assert_raised_with_message("Could not parse the PKCS7: nested asn1 error") do
+          assert_raised_with_message(/Could not parse the PKCS7/) do
             begin
               InstanceAgent::Plugins::CodeDeployPlugin::DeploymentSpecification.parse(@packed_message)
             rescue ArgumentError => e
@@ -591,7 +591,7 @@ class DeploymentSpecificationTest < InstanceAgentTestCase
         should "raise when JSON submitted as PKCS7/JSON" do
           @packed_local_revision_message.payload = @deployment_local_revision_spec.to_json
 
-          assert_raised_with_message("Could not parse the PKCS7: nested asn1 error") do
+          assert_raised_with_message(/Could not parse the PKCS7/) do
             begin
               InstanceAgent::Plugins::CodeDeployPlugin::DeploymentSpecification.parse(@packed_local_revision_message)
             rescue ArgumentError => e


### PR DESCRIPTION
*Issue #, if available:* 301

https://github.com/aws/aws-codedeploy-agent/issues/301

*Description of changes:*

Ensures that the agent can be installed on systems where the system ruby is 3.0 or 3.1, without needing to install a second 2.x ruby version and symlink it in.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

@maths22 I found your fork and included your commits as a starting point. I hope that's OK.
