### PR TITLE
Update dependencies and tests to work on Ruby 3.2

### DIFF
--- a/codedeploy_agent.gemspec
+++ b/codedeploy_agent.gemspec
@@ -11,8 +11,8 @@ Gem::Specification.new do |spec|
   spec.license        = 'Apache-2.0'
   spec.required_ruby_version = '>= 2.7.0'
 
-  spec.add_dependency('gli', '~> 2.5')
-  spec.add_dependency('json_pure', '~> 1.6')
+  spec.add_dependency('gli', '~> 2.11')
+  spec.add_dependency('json_pure', '~> 2.6.3')
   spec.add_dependency('archive-tar-minitar', '~> 0.5.2')
   spec.add_dependency('rubyzip', '~> 1.3.0')
   spec.add_dependency('logging', '~> 2.2')
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency('docopt', '~> 0.5.0')
   spec.add_dependency('concurrent-ruby', '~> 1.1.9')
 
-  spec.add_development_dependency('rake', '~> 12.3.3')
+  spec.add_development_dependency('rake', '~> 13.0.6')
   spec.add_development_dependency('rspec', '~> 3.2.0')
 end

--- a/test/instance_agent/plugins/codedeploy/deployment_specification_test.rb
+++ b/test/instance_agent/plugins/codedeploy/deployment_specification_test.rb
@@ -480,7 +480,7 @@ class DeploymentSpecificationTest < InstanceAgentTestCase
         should "raise when JSON submitted as PKCS7/JSON" do
           @packed_message.payload = @deployment_spec.to_json
 
-          assert_raised_with_message("Could not parse the PKCS7: nested asn1 error") do
+          assert_raise_with_message(RuntimeError, /\ACould not parse the PKCS7:/) do
             begin
               InstanceAgent::Plugins::CodeDeployPlugin::DeploymentSpecification.parse(@packed_message)
             rescue ArgumentError => e
@@ -591,7 +591,7 @@ class DeploymentSpecificationTest < InstanceAgentTestCase
         should "raise when JSON submitted as PKCS7/JSON" do
           @packed_local_revision_message.payload = @deployment_local_revision_spec.to_json
 
-          assert_raised_with_message("Could not parse the PKCS7: nested asn1 error") do
+          assert_raise_with_message(RuntimeError, /\ACould not parse the PKCS7:/) do
             begin
               InstanceAgent::Plugins::CodeDeployPlugin::DeploymentSpecification.parse(@packed_local_revision_message)
             rescue ArgumentError => e


### PR DESCRIPTION
* Bump version of `gli`
* Bump version of `json_pure`
* Bump version of `rake`
* Change expectation of a test for changed error message in OpenSSL

*Description of changes:*

Minimal necessary changes to make the test suite work on Ruby 3.2.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
