### PR TITLE
Revert "Updated expected error message in file_credentials_test"

### DIFF
--- a/test/instance_agent/file_credentials_test.rb
+++ b/test/instance_agent/file_credentials_test.rb
@@ -53,7 +53,7 @@ END
     end
 
     should 'raise error when credential file is missing' do
-      assert_raised_with_message("Profile `default' not found in #{credentials_path}", Aws::Errors::NoSuchProfileError) do
+      assert_raised_with_message("Failed to load credentials from path #{credentials_path}", RuntimeError) do
         InstanceAgent::FileCredentials.new(credentials_path)
       end
     end


### PR DESCRIPTION
This reverts commit 4b4aab1b0794d0363573240fcf81218257663703

Logic to preserve error was added here: 47e3fa58907a1afd11e6118b69919436965a4f1a

This should fix the 1.7.x failing action.

Verified by:
1. Locally updated ruby to 2.7 using rbenv (matching workflow expectation)
2. `bundle install`
3. `bundle exec rake`
```
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
445 tests, 1028 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
12.23 tests/s, 28.26 assertions/s
```