### PR TITLE
fix changedir when unpacking tar/tgz

### DIFF
--- a/lib/instance_agent/platform/linux_util.rb
+++ b/lib/instance_agent/platform/linux_util.rb
@@ -43,9 +43,7 @@ module InstanceAgent
       FileUtils.mkdir_p(dst)
       working_dir = FileUtils.pwd()
       absolute_bundle_path = File.expand_path(bundle_file)
-      FileUtils.cd(dst) do
-        execute_tar_command("/bin/tar -xpsf #{absolute_bundle_path}")
-      end
+      execute_tar_command("/bin/tar -xps -C #{dst} -f #{absolute_bundle_path}")
     end
 
     def self.extract_zip(bundle_file, dst)
@@ -60,9 +58,7 @@ module InstanceAgent
       FileUtils.mkdir_p(dst)
       working_dir = FileUtils.pwd()
       absolute_bundle_path = File.expand_path(bundle_file)
-      FileUtils.cd(dst) do 
-        execute_tar_command("/bin/tar -zxpsf #{absolute_bundle_path}")
-      end
+      execute_tar_command("/bin/tar -zxpsC #{dst} -f #{absolute_bundle_path}")
     end
 
     def self.supports_process_groups?()


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

When running multiple deployments with a `tar`/`tgz` bundle on the same host with the same codeagent instance, there is a chance for a race condition at the `DownloadBundle` step where it may fail with a variety of error messages (eg):

- `Error extracting tar archive: `
- `conflicting chdir during another chdir block`

This change removes the use of `FileUtils.cd` when spawning the `tar` command in favour for tar's `-C` option which sets the changes the directory when running the command. This resolves any contention on the current directory as the directory is changed within each process' respective shells.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
