### PR TITLE
chore: bump to version 1.8

### DIFF
--- a/codedeploy_agent.gemspec
+++ b/codedeploy_agent.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'aws_codedeploy_agent'
-  spec.version       = '1.7.1'
+  spec.version       = '1.8.0'
   spec.summary       = 'Packages AWS CodeDeploy agent libraries'
   spec.description   = 'AWS CodeDeploy agent is responsible for doing the actual work of deploying software on an individual EC2 instance'
   spec.author        = 'Amazon Web Services'


### PR DESCRIPTION
Changed: Upgraded the bundled Ruby to 3.2 in the CodeDeploy agent for Windows.

With this release https://github.com/aws/aws-codedeploy-agent/releases/tag/v1.8.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.