### PR TITLE
Fix network ordering in codedeploy-agent.service

### DIFF
--- a/init.d/codedeploy-agent.service
+++ b/init.d/codedeploy-agent.service
@@ -1,9 +1,10 @@
 [Unit]
 Description=AWS CodeDeploy Host Agent
+Wants=network-online.target nss-lookup.target
+After=network-online.target nss-lookup.target
 
 [Service]
 Type=forking
-After=network.target
 ExecStart=/bin/bash -a -c '[ -f /etc/profile ] && source /etc/profile; /opt/codedeploy-agent/bin/codedeploy-agent start'
 ExecStop=/opt/codedeploy-agent/bin/codedeploy-agent stop
 RemainAfterExit=no


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

The [Unit] section was missing Wants= and After= for network-online.target and nss-lookup.target, meaning the agent could start before DNS is available. The existing After=network.target in [Service] had no effect as After= is a [Unit] directive and is silently ignored in [Service].

This fixes a boot-time race condition where the agent exits with SocketError on the CodeDeploy commands endpoint before DNS is ready.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.