### PR TITLE
Remove stale annotations and a dangling comment fragment

### DIFF
--- a/src/aws_clients/s3_client.rs
+++ b/src/aws_clients/s3_client.rs
@@ -160,7 +160,6 @@ fn build_custom_http_client(
         return None;
     }
 
-    // that grcov cannot attribute to source lines.
     // Build the TLS context once (custom CA certs, if any). `proxy_config` lives
     // on the low-level `ConnectorBuilder`, not the high-level `Builder`, so we
     // assemble the connector per-invocation inside `build_with_connector_fn`

--- a/src/aws_clients/wire_log.rs
+++ b/src/aws_clients/wire_log.rs
@@ -1,5 +1,3 @@
-//! @risk medium
-//!
 //! Amazon S3 HTTP wire logging (`:log_aws_wire:`).
 //!
 //! When the `log_aws_wire` config setting is enabled, [`WireLogInterceptor`] is

--- a/src/command_poller/host_command_poller.rs
+++ b/src/command_poller/host_command_poller.rs
@@ -1,5 +1,3 @@
-//! @risk medium
-//!
 //! Host command polling loop.
 //!
 //! Polls the `CodeDeploy` service for host commands and submits them

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,5 +1,3 @@
-//! @risk medium
-//!
 //! Agent configuration — YAML-based config file parsing and defaults.
 //!
 //! Loads YAML from `/etc/codedeploy-agent/conf/codedeployagent.yml` and merges

--- a/src/host_command/bundle_downloader/local_directory.rs
+++ b/src/host_command/bundle_downloader/local_directory.rs
@@ -1,5 +1,3 @@
-//! @risk medium
-//!
 //! Local directory downloader — recursive copy.
 //!
 //! Copies instead of symlinking to preserve revision history.

--- a/src/host_command/bundle_unpacker.rs
+++ b/src/host_command/bundle_unpacker.rs
@@ -1,5 +1,3 @@
-//! @risk medium
-//!
 //! Bundle archive unpacking.
 //!
 //! Extracts tar/tgz/zip archives and strips a leading directory if the archive

--- a/src/host_command/commands/download_bundle.rs
+++ b/src/host_command/commands/download_bundle.rs
@@ -1,5 +1,3 @@
-//! @risk medium
-//!
 //! `DownloadBundle` command.
 //!
 //! Cleans up old archives, downloads the bundle from the appropriate source

--- a/src/host_command/commands/hook.rs
+++ b/src/host_command/commands/hook.rs
@@ -1,5 +1,3 @@
-//! @risk medium
-//!
 //! Hook command — runs lifecycle event scripts.
 //!
 //! Maps command names to lists of lifecycle event names, then creates and

--- a/src/installer/commands/change_acl_command.rs
+++ b/src/installer/commands/change_acl_command.rs
@@ -1,5 +1,3 @@
-//! @risk medium
-//!
 //! `setfacl` command — sets POSIX ACLs on installed files.
 use crate::application_specification::{Acl, AclEntry};
 use crate::installer::{InstallerError, Result};

--- a/src/installer/commands/change_context_command.rs
+++ b/src/installer/commands/change_context_command.rs
@@ -1,5 +1,3 @@
-//! @risk medium
-//!
 //! `semanage fcontext` command — sets `SELinux` file context.
 use crate::application_specification::SeLinuxContext;
 use crate::installer::{InstallerError, Result};

--- a/src/installer/commands/change_mode_command.rs
+++ b/src/installer/commands/change_mode_command.rs
@@ -1,5 +1,3 @@
-//! @risk medium
-//!
 //! `chmod` command — sets file permissions.
 use crate::installer::{InstallerError, Result};
 use serde_json::{Value, json};

--- a/src/installer/commands/change_owner_command.rs
+++ b/src/installer/commands/change_owner_command.rs
@@ -1,5 +1,3 @@
-//! @risk medium
-//!
 //! `chown` command — sets file ownership.
 use crate::installer::Result;
 use serde_json::{Value, json};

--- a/src/installer/core.rs
+++ b/src/installer/core.rs
@@ -1,5 +1,3 @@
-//! @risk high
-//!
 //! Installer core — executes install commands and manages cleanup files.
 #[cfg(unix)]
 use super::commands::RemoveContextCommand;
@@ -98,7 +96,7 @@ impl Installer {
         self
     }
 
-    /// @risk high — writes files to customer filesystem, wrong behavior corrupts deployments
+    /// Writes files to the customer filesystem; wrong behavior corrupts deployments.
     ///
     /// # Errors
     /// Returns an error if installation fails.

--- a/src/installer/safe_fs.rs
+++ b/src/installer/safe_fs.rs
@@ -1,5 +1,3 @@
-//! @risk high
-//!
 //! Symlink-safe destination guards for permission commands.
 //!
 //! The install instruction list runs every `CopyCommand` first and only then

--- a/src/lifecycle_event/script.rs
+++ b/src/lifecycle_event/script.rs
@@ -1,5 +1,3 @@
-//! @risk medium
-//!
 //! Script execution with real-time stream logging.
 //!
 //! [`Script::execute`] is the sync entry point — it creates a tokio runtime internally

--- a/src/logging/agent_logger.rs
+++ b/src/logging/agent_logger.rs
@@ -1,5 +1,3 @@
-//! @risk low
-//!
 //! Agent log configuration — file rotation and format setup.
 
 use std::fs::{self, File, OpenOptions};

--- a/src/logging/deployment_logger.rs
+++ b/src/logging/deployment_logger.rs
@@ -1,5 +1,3 @@
-//! @risk low
-//!
 //! Per-deployment log file writer.
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Write};

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,5 +1,3 @@
-//! @risk low
-//!
 //! Platform-appropriate default paths for the `CodeDeploy` agent.
 //!
 //! Each function returns the canonical default path for the current platform,

--- a/src/system/file_ops.rs
+++ b/src/system/file_ops.rs
@@ -1,5 +1,3 @@
-//! @risk medium
-//!
 //! Platform-specific file operations with retry logic
 //!
 //! This module provides a trait-based abstraction for file operations that need

--- a/src/system/linux_ops.rs
+++ b/src/system/linux_ops.rs
@@ -1,5 +1,3 @@
-//! @risk medium
-//!
 //! Linux-specific system operations — `setfacl`.
 use std::io;
 use std::path::Path;

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -1,5 +1,3 @@
-//! @risk low
-//!
 //! System abstraction layer — file ops, process ops, `SELinux`, env vars.
 pub mod env_ops;
 pub mod file_ops;

--- a/src/system/version_file.rs
+++ b/src/system/version_file.rs
@@ -1,5 +1,3 @@
-//! @risk low
-//!
 //! Agent version-tracking file (`.version`).
 //!
 //! The `.version` file is part of the agent's documented install layout: it


### PR DESCRIPTION
Drop leftover module-level annotation comments that carry no information, reword one inline annotation as a plain doc sentence, and remove a comment fragment in s3_client.rs orphaned by an earlier cleanup.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
